### PR TITLE
Fix go:embed placement during top-level type reordering

### DIFF
--- a/packages/formatter/formatter_test.go
+++ b/packages/formatter/formatter_test.go
@@ -68,6 +68,58 @@ func run() {
 }
 
 func TestFormatRepairsGoEmbedDirectivePlacement(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		directive string
+	}{
+		{
+			name:      "space separated directive",
+			directive: "//go:embed foo.txt",
+		},
+		{
+			name:      "tab separated directive",
+			directive: "//go:embed\tfoo.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			path := filepath.Join(root, "sample.go")
+			testutil.WriteGoFile(t, path, "package sample\n\nimport \"embed\"\n\n"+tt.directive+"\n\ntype runtime struct{}\n\nvar rootTemplateFS embed.FS\n")
+
+			report, err := formatter.Format([]string{root}, config.Default())
+
+			if err != nil {
+				t.Fatalf("format: %v", err)
+			}
+
+			if report.Result != "fixed" {
+				t.Fatalf("expected fixed result, got %q", report.Result)
+			}
+
+			content, err := os.ReadFile(path)
+
+			if err != nil {
+				t.Fatalf("read file: %v", err)
+			}
+
+			expected := "package sample\n\nimport \"embed\"\n\n" + tt.directive + "\nvar rootTemplateFS embed.FS\n\ntype runtime struct{}\n"
+
+			if string(content) != expected {
+				t.Fatalf("expected repaired go:embed placement, got:\n%s", content)
+			}
+		})
+	}
+}
+
+func TestFormatLeavesAlreadyFormattedFileUnchanged(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "sample.go")
 	testutil.WriteGoFile(t, path, `package sample
@@ -75,11 +127,16 @@ func TestFormatRepairsGoEmbedDirectivePlacement(t *testing.T) {
 import "embed"
 
 //go:embed foo.txt
+var rootTemplateFS embed.FS
 
 type runtime struct{}
-
-var rootTemplateFS embed.FS
 `)
+
+	original, err := os.ReadFile(path)
+
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
 
 	report, err := formatter.Format([]string{root}, config.Default())
 
@@ -87,8 +144,8 @@ var rootTemplateFS embed.FS
 		t.Fatalf("format: %v", err)
 	}
 
-	if report.Result != "fixed" {
-		t.Fatalf("expected fixed result, got %q", report.Result)
+	if report.Result != "pass" {
+		t.Fatalf("expected pass result, got %q", report.Result)
 	}
 
 	content, err := os.ReadFile(path)
@@ -97,17 +154,7 @@ var rootTemplateFS embed.FS
 		t.Fatalf("read file: %v", err)
 	}
 
-	expected := `package sample
-
-import "embed"
-
-//go:embed foo.txt
-var rootTemplateFS embed.FS
-
-type runtime struct{}
-`
-
-	if string(content) != expected {
-		t.Fatalf("expected repaired go:embed placement, got:\n%s", content)
+	if string(content) != string(original) {
+		t.Fatalf("expected unchanged file, got:\n%s", content)
 	}
 }

--- a/packages/formatter/formatter_test.go
+++ b/packages/formatter/formatter_test.go
@@ -66,3 +66,48 @@ func run() {
 		t.Fatalf("expected formatted file, got:\n%s", content)
 	}
 }
+
+func TestFormatRepairsGoEmbedDirectivePlacement(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "sample.go")
+	testutil.WriteGoFile(t, path, `package sample
+
+import "embed"
+
+//go:embed foo.txt
+
+type runtime struct{}
+
+var rootTemplateFS embed.FS
+`)
+
+	report, err := formatter.Format([]string{root}, config.Default())
+
+	if err != nil {
+		t.Fatalf("format: %v", err)
+	}
+
+	if report.Result != "fixed" {
+		t.Fatalf("expected fixed result, got %q", report.Result)
+	}
+
+	content, err := os.ReadFile(path)
+
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	expected := `package sample
+
+import "embed"
+
+//go:embed foo.txt
+var rootTemplateFS embed.FS
+
+type runtime struct{}
+`
+
+	if string(content) != expected {
+		t.Fatalf("expected repaired go:embed placement, got:\n%s", content)
+	}
+}

--- a/packages/formatter/formatter_test.go
+++ b/packages/formatter/formatter_test.go
@@ -119,6 +119,58 @@ func TestFormatRepairsGoEmbedDirectivePlacement(t *testing.T) {
 	}
 }
 
+func TestFormatPreservesImportsBeforeAnchoredDecls(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		directive string
+	}{
+		{
+			name:      "space separated directive",
+			directive: "//go:embed foo.txt",
+		},
+		{
+			name:      "tab separated directive",
+			directive: "//go:embed\tfoo.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			path := filepath.Join(root, "sample.go")
+			testutil.WriteGoFile(t, path, "package sample\n\n"+tt.directive+"\n\nimport \"embed\"\n\ntype runtime struct{}\n\nvar rootTemplateFS embed.FS\n")
+
+			report, err := formatter.Format([]string{root}, config.Default())
+
+			if err != nil {
+				t.Fatalf("format: %v", err)
+			}
+
+			if report.Result != "fixed" {
+				t.Fatalf("expected fixed result, got %q", report.Result)
+			}
+
+			content, err := os.ReadFile(path)
+
+			if err != nil {
+				t.Fatalf("read file: %v", err)
+			}
+
+			expected := "package sample\n\nimport \"embed\"\n\n" + tt.directive + "\nvar rootTemplateFS embed.FS\n\ntype runtime struct{}\n"
+
+			if string(content) != expected {
+				t.Fatalf("expected imports to remain before anchored declaration, got:\n%s", content)
+			}
+		})
+	}
+}
+
 func TestFormatLeavesAlreadyFormattedFileUnchanged(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "sample.go")

--- a/packages/formatter/rules/spacing/spacing.go
+++ b/packages/formatter/rules/spacing/spacing.go
@@ -19,6 +19,12 @@ type Rule struct{}
 
 type importAliases map[string]string
 
+type declBlock struct {
+	decl         ast.Decl
+	effectivePos token.Pos
+	anchored     bool
+}
+
 var stdlibSpacingImports = map[string]string{
 	"sort":         "sort",
 	"slices":       "slices",
@@ -126,6 +132,7 @@ func analyse(filename string, src []byte) ([]rules.Violation, []byte, error) {
 	}
 
 	violations = append(violations, typeOrderViolations(file, fset, filename)...)
+	violations = append(violations, embedAdjacencyViolations(file, fset, filename)...)
 
 	formatted := src
 
@@ -133,17 +140,17 @@ func analyse(filename string, src []byte) ([]rules.Violation, []byte, error) {
 		formatted = applyInsertions(formatted, insertions)
 	}
 
-	if len(violations) > 0 {
-		reordered, changed, err := reorderTypeDecls(filename, formatted)
+	reordered, changed, err := reorderTypeDecls(filename, formatted)
 
-		if err != nil {
-			return nil, nil, err
-		}
-
-		if changed {
-			formatted = reordered
-		}
+	if err != nil {
+		return nil, nil, err
 	}
+
+	if changed {
+		formatted = reordered
+	}
+
+	formatted = collapseEmbedSpacing(formatted)
 
 	return violations, formatted, nil
 }
@@ -559,19 +566,22 @@ func typeOrderViolations(file *ast.File, fset *token.FileSet, filename string) [
 	var violations []rules.Violation
 	seenNonType := false
 
-	for _, decl := range file.Decls {
-		genDecl, ok := decl.(*ast.GenDecl)
-
-		if ok && genDecl.Tok == token.IMPORT {
+	for _, block := range topLevelDeclBlocks(file) {
+		if isImportDecl(block.decl) {
 			continue
 		}
 
-		if isTypeDecl(decl) {
+		if block.anchored {
+			seenNonType = false
+			continue
+		}
+
+		if isTypeDecl(block.decl) {
 			if seenNonType {
 				violations = append(violations, rules.Violation{
 					Rule:    "spacing",
 					File:    filename,
-					Line:    fset.Position(decl.Pos()).Line,
+					Line:    fset.Position(block.decl.Pos()).Line,
 					Message: "type definitions must appear at the beginning of the file",
 				})
 			}
@@ -593,32 +603,13 @@ func reorderTypeDecls(filename string, src []byte) ([]byte, bool, error) {
 		return nil, false, err
 	}
 
-	if !hasOutOfOrderTypeDecls(file) {
+	desired := desiredDeclOrder(file)
+
+	if declOrdersEqual(file.Decls, desired) {
 		return src, false, nil
 	}
 
-	importsEnd := 0
-
-	for importsEnd < len(file.Decls) && isImportDecl(file.Decls[importsEnd]) {
-		importsEnd++
-	}
-
-	reordered := make([]ast.Decl, 0, len(file.Decls))
-	reordered = append(reordered, file.Decls[:importsEnd]...)
-
-	for _, decl := range file.Decls[importsEnd:] {
-		if isTypeDecl(decl) {
-			reordered = append(reordered, decl)
-		}
-	}
-
-	for _, decl := range file.Decls[importsEnd:] {
-		if !isTypeDecl(decl) {
-			reordered = append(reordered, decl)
-		}
-	}
-
-	file.Decls = reordered
+	file.Decls = desired
 
 	var out bytes.Buffer
 
@@ -629,15 +620,207 @@ func reorderTypeDecls(filename string, src []byte) ([]byte, bool, error) {
 	return out.Bytes(), true, nil
 }
 
-func hasOutOfOrderTypeDecls(file *ast.File) bool {
-	seenNonType := false
+func embedAdjacencyViolations(file *ast.File, fset *token.FileSet, filename string) []rules.Violation {
+	var violations []rules.Violation
 
-	for _, decl := range file.Decls {
-		if isImportDecl(decl) {
+	for decl, group := range embedDirectiveMatches(file) {
+		commentEndLine := fset.Position(group.End()).Line
+		declLine := fset.Position(decl.Pos()).Line
+
+		if declLine == commentEndLine+1 {
 			continue
 		}
 
-		if isTypeDecl(decl) {
+		violations = append(violations, rules.Violation{
+			Rule:    "spacing",
+			File:    filename,
+			Line:    declLine,
+			Message: "go:embed directives must remain immediately above the following var declaration",
+		})
+	}
+
+	return violations
+}
+
+func topLevelDeclBlocks(file *ast.File) []declBlock {
+	matches := embedDirectiveMatches(file)
+	blocks := make([]declBlock, 0, len(file.Decls))
+
+	for _, decl := range file.Decls {
+		block := declBlock{
+			decl:         decl,
+			effectivePos: decl.Pos(),
+		}
+
+		if group, ok := matches[decl]; ok && group.Pos() < block.effectivePos {
+			block.effectivePos = group.Pos()
+			block.anchored = true
+		}
+
+		blocks = append(blocks, block)
+	}
+
+	slices.SortStableFunc(blocks, func(a declBlock, b declBlock) int {
+		switch {
+		case a.effectivePos < b.effectivePos:
+			return -1
+		case a.effectivePos > b.effectivePos:
+			return 1
+		default:
+			return 0
+		}
+	})
+
+	return blocks
+}
+
+func desiredDeclOrder(file *ast.File) []ast.Decl {
+	blocks := topLevelDeclBlocks(file)
+	importsEnd := 0
+
+	for importsEnd < len(blocks) && isImportDecl(blocks[importsEnd].decl) {
+		importsEnd++
+	}
+
+	reordered := make([]ast.Decl, 0, len(blocks))
+
+	for _, block := range blocks[:importsEnd] {
+		reordered = append(reordered, block.decl)
+	}
+
+	segment := make([]declBlock, 0, len(blocks)-importsEnd)
+	flush := func() {
+		for _, block := range segment {
+			if isTypeDecl(block.decl) {
+				reordered = append(reordered, block.decl)
+			}
+		}
+
+		for _, block := range segment {
+			if !isTypeDecl(block.decl) {
+				reordered = append(reordered, block.decl)
+			}
+		}
+
+		segment = segment[:0]
+	}
+
+	for _, block := range blocks[importsEnd:] {
+		if block.anchored {
+			flush()
+			reordered = append(reordered, block.decl)
+			continue
+		}
+
+		segment = append(segment, block)
+	}
+
+	flush()
+
+	return reordered
+}
+
+func declOrdersEqual(current []ast.Decl, desired []ast.Decl) bool {
+	if len(current) != len(desired) {
+		return false
+	}
+
+	for i := range current {
+		if current[i] != desired[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func embedDirectiveMatches(file *ast.File) map[ast.Decl]*ast.CommentGroup {
+	matches := map[ast.Decl]*ast.CommentGroup{}
+	docGroups := map[*ast.CommentGroup]struct{}{}
+	varDecls := topLevelVarDecls(file)
+
+	for _, decl := range varDecls {
+		genDecl, ok := decl.(*ast.GenDecl)
+
+		if !ok || genDecl.Doc == nil || !containsEmbedDirective(genDecl.Doc) {
+			continue
+		}
+
+		matches[decl] = genDecl.Doc
+		docGroups[genDecl.Doc] = struct{}{}
+	}
+
+	for _, group := range file.Comments {
+		if !containsEmbedDirective(group) {
+			continue
+		}
+
+		if _, ok := docGroups[group]; ok {
+			continue
+		}
+
+		if decl, ok := nextTopLevelVarDeclAfter(varDecls, group.End()); ok {
+			if _, seen := matches[decl]; !seen {
+				matches[decl] = group
+			}
+		}
+	}
+
+	return matches
+}
+
+func topLevelVarDecls(file *ast.File) []ast.Decl {
+	var decls []ast.Decl
+
+	for _, decl := range file.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+
+		if ok && genDecl.Tok == token.VAR {
+			decls = append(decls, decl)
+		}
+	}
+
+	return decls
+}
+
+func nextTopLevelVarDeclAfter(decls []ast.Decl, pos token.Pos) (ast.Decl, bool) {
+	for _, decl := range decls {
+		if decl.Pos() > pos {
+			return decl, true
+		}
+	}
+
+	return nil, false
+}
+
+func containsEmbedDirective(group *ast.CommentGroup) bool {
+	if group == nil {
+		return false
+	}
+
+	for _, comment := range group.List {
+		if strings.HasPrefix(strings.TrimSpace(comment.Text), "//go:embed ") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasOutOfOrderTypeDecls(file *ast.File) bool {
+	seenNonType := false
+
+	for _, block := range topLevelDeclBlocks(file) {
+		if isImportDecl(block.decl) {
+			continue
+		}
+
+		if block.anchored {
+			seenNonType = false
+			continue
+		}
+
+		if isTypeDecl(block.decl) {
 			if seenNonType {
 				return true
 			}
@@ -649,6 +832,52 @@ func hasOutOfOrderTypeDecls(file *ast.File) bool {
 	}
 
 	return false
+}
+
+func collapseEmbedSpacing(src []byte) []byte {
+	lines := bytes.Split(src, []byte{'\n'})
+	out := make([][]byte, 0, len(lines))
+
+	for i := 0; i < len(lines); i++ {
+		out = append(out, lines[i])
+
+		if i+2 >= len(lines) {
+			continue
+		}
+
+		if !bytes.HasPrefix(bytes.TrimSpace(lines[i]), []byte("//go:embed ")) {
+			continue
+		}
+
+		if len(bytes.TrimSpace(lines[i+1])) != 0 {
+			continue
+		}
+
+		next := bytes.TrimSpace(lines[i+2])
+
+		if isVarDeclStart(next) {
+			i++
+		}
+	}
+
+	return bytes.Join(out, []byte{'\n'})
+}
+
+func isVarDeclStart(line []byte) bool {
+	if !bytes.HasPrefix(line, []byte("var")) {
+		return false
+	}
+
+	if len(line) == len("var") {
+		return true
+	}
+
+	switch line[len("var")] {
+	case ' ', '\t', '\n', '\r', '\f', '\v', '(':
+		return true
+	default:
+		return false
+	}
 }
 
 func buildLineStarts(src []byte) []int {

--- a/packages/formatter/rules/spacing/spacing.go
+++ b/packages/formatter/rules/spacing/spacing.go
@@ -581,6 +581,7 @@ func typeOrderViolations(file *ast.File, fset *token.FileSet, filename string) [
 
 		if block.anchored {
 			seenNonType = false
+
 			continue
 		}
 
@@ -804,6 +805,7 @@ func desiredDeclOrder(file *ast.File) []ast.Decl {
 		if block.anchored {
 			flush()
 			reordered = append(reordered, block.decl)
+
 			continue
 		}
 
@@ -926,6 +928,7 @@ func hasOutOfOrderTypeDecls(file *ast.File) bool {
 
 		if block.anchored {
 			seenNonType = false
+
 			continue
 		}
 

--- a/packages/formatter/rules/spacing/spacing.go
+++ b/packages/formatter/rules/spacing/spacing.go
@@ -151,6 +151,12 @@ func analyse(filename string, src []byte) ([]rules.Violation, []byte, error) {
 			formatted = reordered
 		}
 
+		formatted, err = repairDetachedEmbedDirectives(filename, formatted)
+
+		if err != nil {
+			return nil, nil, err
+		}
+
 		formatted = collapseEmbedSpacing(formatted)
 	}
 
@@ -605,6 +611,8 @@ func reorderTypeDecls(filename string, src []byte) ([]byte, bool, error) {
 		return nil, false, err
 	}
 
+	attachEmbedDirectiveDocs(file)
+
 	desired := desiredDeclOrder(file)
 
 	if declOrdersEqual(file.Decls, desired) {
@@ -620,6 +628,18 @@ func reorderTypeDecls(filename string, src []byte) ([]byte, bool, error) {
 	}
 
 	return out.Bytes(), true, nil
+}
+
+func attachEmbedDirectiveDocs(file *ast.File) {
+	for decl, group := range embedDirectiveMatches(file) {
+		genDecl, ok := decl.(*ast.GenDecl)
+
+		if !ok || genDecl.Doc != nil {
+			continue
+		}
+
+		genDecl.Doc = group
+	}
 }
 
 func embedAdjacencyViolations(file *ast.File, fset *token.FileSet, filename string) []rules.Violation {
@@ -642,6 +662,77 @@ func embedAdjacencyViolations(file *ast.File, fset *token.FileSet, filename stri
 	}
 
 	return violations
+}
+
+func repairDetachedEmbedDirectives(filename string, src []byte) ([]byte, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, src, parser.ParseComments)
+
+	if err != nil {
+		return nil, err
+	}
+
+	type embedMove struct {
+		commentStartLine int
+		commentEndLine   int
+		declLine         int
+	}
+
+	var moves []embedMove
+
+	for decl, group := range embedDirectiveMatches(file) {
+		commentEndLine := fset.Position(group.End()).Line
+		declLine := fset.Position(decl.Pos()).Line
+
+		if declLine == commentEndLine+1 {
+			continue
+		}
+
+		moves = append(moves, embedMove{
+			commentStartLine: fset.Position(group.Pos()).Line,
+			commentEndLine:   commentEndLine,
+			declLine:         declLine,
+		})
+	}
+
+	if len(moves) == 0 {
+		return src, nil
+	}
+
+	lines := bytes.SplitAfter(src, []byte{'\n'})
+
+	slices.SortStableFunc(moves, func(a embedMove, b embedMove) int {
+		switch {
+		case a.commentStartLine > b.commentStartLine:
+			return -1
+		case a.commentStartLine < b.commentStartLine:
+			return 1
+		default:
+			return 0
+		}
+	})
+
+	for _, move := range moves {
+		groupStart := move.commentStartLine - 1
+		groupEnd := move.commentEndLine
+		insertAt := move.declLine - 1
+		removeEnd := groupEnd
+
+		if groupEnd < len(lines) && len(bytes.TrimSpace(lines[groupEnd])) == 0 {
+			removeEnd++
+		}
+
+		groupLines := append([][]byte(nil), lines[groupStart:groupEnd]...)
+		lines = append(lines[:groupStart], lines[removeEnd:]...)
+
+		if insertAt > groupStart {
+			insertAt -= removeEnd - groupStart
+		}
+
+		lines = append(lines[:insertAt], append(groupLines, lines[insertAt:]...)...)
+	}
+
+	return bytes.Join(lines, nil), nil
 }
 
 func topLevelDeclBlocks(file *ast.File) []declBlock {
@@ -678,16 +769,14 @@ func topLevelDeclBlocks(file *ast.File) []declBlock {
 
 func desiredDeclOrder(file *ast.File) []ast.Decl {
 	blocks := topLevelDeclBlocks(file)
-	importsEnd := 0
-
-	for importsEnd < len(blocks) && isImportDecl(blocks[importsEnd].decl) {
-		importsEnd++
-	}
+	importsEnd := leadingImportDeclsEnd(file.Decls)
+	preservedImports := map[ast.Decl]struct{}{}
 
 	reordered := make([]ast.Decl, 0, len(blocks))
 
-	for _, block := range blocks[:importsEnd] {
-		reordered = append(reordered, block.decl)
+	for _, decl := range file.Decls[:importsEnd] {
+		reordered = append(reordered, decl)
+		preservedImports[decl] = struct{}{}
 	}
 
 	segment := make([]declBlock, 0, len(blocks)-importsEnd)
@@ -707,7 +796,11 @@ func desiredDeclOrder(file *ast.File) []ast.Decl {
 		segment = segment[:0]
 	}
 
-	for _, block := range blocks[importsEnd:] {
+	for _, block := range blocks {
+		if _, ok := preservedImports[block.decl]; ok {
+			continue
+		}
+
 		if block.anchored {
 			flush()
 			reordered = append(reordered, block.decl)
@@ -720,6 +813,16 @@ func desiredDeclOrder(file *ast.File) []ast.Decl {
 	flush()
 
 	return reordered
+}
+
+func leadingImportDeclsEnd(decls []ast.Decl) int {
+	importsEnd := 0
+
+	for importsEnd < len(decls) && isImportDecl(decls[importsEnd]) {
+		importsEnd++
+	}
+
+	return importsEnd
 }
 
 func declOrdersEqual(current []ast.Decl, desired []ast.Decl) bool {

--- a/packages/formatter/rules/spacing/spacing.go
+++ b/packages/formatter/rules/spacing/spacing.go
@@ -140,17 +140,19 @@ func analyse(filename string, src []byte) ([]rules.Violation, []byte, error) {
 		formatted = applyInsertions(formatted, insertions)
 	}
 
-	reordered, changed, err := reorderTypeDecls(filename, formatted)
+	if len(violations) > 0 {
+		reordered, changed, err := reorderTypeDecls(filename, formatted)
 
-	if err != nil {
-		return nil, nil, err
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if changed {
+			formatted = reordered
+		}
+
+		formatted = collapseEmbedSpacing(formatted)
 	}
-
-	if changed {
-		formatted = reordered
-	}
-
-	formatted = collapseEmbedSpacing(formatted)
 
 	return violations, formatted, nil
 }
@@ -793,13 +795,17 @@ func nextTopLevelVarDeclAfter(decls []ast.Decl, pos token.Pos) (ast.Decl, bool) 
 	return nil, false
 }
 
+func isEmbedDirectiveText(text string) bool {
+	return hasEmbedDirectivePrefix(strings.TrimSpace(text))
+}
+
 func containsEmbedDirective(group *ast.CommentGroup) bool {
 	if group == nil {
 		return false
 	}
 
 	for _, comment := range group.List {
-		if strings.HasPrefix(strings.TrimSpace(comment.Text), "//go:embed ") {
+		if isEmbedDirectiveText(comment.Text) {
 			return true
 		}
 	}
@@ -845,7 +851,7 @@ func collapseEmbedSpacing(src []byte) []byte {
 			continue
 		}
 
-		if !bytes.HasPrefix(bytes.TrimSpace(lines[i]), []byte("//go:embed ")) {
+		if !isEmbedDirectiveLine(lines[i]) {
 			continue
 		}
 
@@ -861,6 +867,40 @@ func collapseEmbedSpacing(src []byte) []byte {
 	}
 
 	return bytes.Join(out, []byte{'\n'})
+}
+
+func isEmbedDirectiveLine(line []byte) bool {
+	return hasEmbedDirectiveLinePrefix(bytes.TrimSpace(line))
+}
+
+func hasEmbedDirectivePrefix(text string) bool {
+	const prefix = "//go:embed"
+
+	if !strings.HasPrefix(text, prefix) || len(text) == len(prefix) {
+		return false
+	}
+
+	switch text[len(prefix)] {
+	case ' ', '\t':
+		return true
+	default:
+		return false
+	}
+}
+
+func hasEmbedDirectiveLinePrefix(line []byte) bool {
+	const prefix = "//go:embed"
+
+	if !bytes.HasPrefix(line, []byte(prefix)) || len(line) == len(prefix) {
+		return false
+	}
+
+	switch line[len(prefix)] {
+	case ' ', '\t':
+		return true
+	default:
+		return false
+	}
 }
 
 func isVarDeclStart(line []byte) bool {

--- a/packages/formatter/rules/spacing/spacing_test.go
+++ b/packages/formatter/rules/spacing/spacing_test.go
@@ -1040,6 +1040,99 @@ func run() {
 	}
 }
 
+func TestApplyRepairsDetachedGoEmbedDirective(t *testing.T) {
+	path := writeTempGoFile(t, `package sample
+
+import "embed"
+
+//go:embed foo.txt
+
+type runtime struct{}
+
+var rootTemplateFS embed.FS
+`)
+
+	violations, formatted, err := New().Apply(path, mustReadFile(t, path))
+
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	expected := `package sample
+
+import "embed"
+
+//go:embed foo.txt
+var rootTemplateFS embed.FS
+
+type runtime struct{}
+`
+
+	if string(formatted) != expected {
+		t.Fatalf("expected repaired go:embed placement, got:\n%s", formatted)
+	}
+}
+
+func TestApplyKeepsAttachedGoEmbedDirectiveUnchanged(t *testing.T) {
+	path := writeTempGoFile(t, `package sample
+
+import "embed"
+
+//go:embed foo.txt
+var rootTemplateFS embed.FS
+
+type runtime struct{}
+`)
+
+	original := string(mustReadFile(t, path))
+	violations, formatted, err := New().Apply(path, []byte(original))
+
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if len(violations) != 0 {
+		t.Fatalf("expected 0 violations, got %d", len(violations))
+	}
+
+	if string(formatted) != original {
+		t.Fatalf("expected unchanged output, got:\n%s", formatted)
+	}
+}
+
+func TestApplyReordersTypesWithoutEmbedDirective(t *testing.T) {
+	path := writeTempGoFile(t, `package sample
+
+import "fmt"
+
+var defaultName = "ok"
+
+type config struct{}
+
+func run() {
+	fmt.Println(defaultName)
+}
+`)
+
+	violations, formatted, err := New().Apply(path, mustReadFile(t, path))
+
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	if !strings.Contains(string(formatted), "type config struct{}\n\nvar defaultName = \"ok\"") {
+		t.Fatalf("expected type declaration reorder, got:\n%s", formatted)
+	}
+}
+
 func TestApplyFormatsBlankLinesAroundGenericSelectorCalls(t *testing.T) {
 	path := writeTempGoFile(t, `package sample
 

--- a/packages/formatter/rules/spacing/spacing_test.go
+++ b/packages/formatter/rules/spacing/spacing_test.go
@@ -1143,6 +1143,50 @@ func TestApplyRepairsDetachedGoEmbedDirectiveWithTab(t *testing.T) {
 	}
 }
 
+func TestApplyPreservesImportsBeforeAnchoredDecls(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		directive string
+	}{
+		{
+			name:      "space separated directive",
+			directive: "//go:embed foo.txt",
+		},
+		{
+			name:      "tab separated directive",
+			directive: "//go:embed\tfoo.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := writeTempGoFile(t, "package sample\n\n"+tt.directive+"\n\nimport \"embed\"\n\ntype runtime struct{}\n\nvar rootTemplateFS embed.FS\n")
+
+			violations, formatted, err := New().Apply(path, mustReadFile(t, path))
+
+			if err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+
+			if len(violations) != 1 {
+				t.Fatalf("expected 1 violation, got %d", len(violations))
+			}
+
+			expected := "package sample\n\nimport \"embed\"\n\n" + tt.directive + "\nvar rootTemplateFS embed.FS\n\ntype runtime struct{}\n"
+
+			if string(formatted) != expected {
+				t.Fatalf("expected imports to remain before anchored declaration, got:\n%s", formatted)
+			}
+		})
+	}
+}
+
 func TestIsEmbedDirectiveTextRejectsInvalidPrefixes(t *testing.T) {
 	t.Parallel()
 

--- a/packages/formatter/rules/spacing/spacing_test.go
+++ b/packages/formatter/rules/spacing/spacing_test.go
@@ -1104,6 +1104,88 @@ type runtime struct{}
 	}
 }
 
+func TestApplyKeepsAttachedGoEmbedDirectiveWithTabUnchanged(t *testing.T) {
+	path := writeTempGoFile(t, "package sample\n\nimport \"embed\"\n\n//go:embed\tfoo.txt\nvar rootTemplateFS embed.FS\n\ntype runtime struct{}\n")
+
+	original := string(mustReadFile(t, path))
+	violations, formatted, err := New().Apply(path, []byte(original))
+
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if len(violations) != 0 {
+		t.Fatalf("expected 0 violations, got %d", len(violations))
+	}
+
+	if string(formatted) != original {
+		t.Fatalf("expected unchanged output, got:\n%s", formatted)
+	}
+}
+
+func TestApplyRepairsDetachedGoEmbedDirectiveWithTab(t *testing.T) {
+	path := writeTempGoFile(t, "package sample\n\nimport \"embed\"\n\n//go:embed\tfoo.txt\n\ntype runtime struct{}\n\nvar rootTemplateFS embed.FS\n")
+
+	violations, formatted, err := New().Apply(path, mustReadFile(t, path))
+
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	expected := "package sample\n\nimport \"embed\"\n\n//go:embed\tfoo.txt\nvar rootTemplateFS embed.FS\n\ntype runtime struct{}\n"
+
+	if string(formatted) != expected {
+		t.Fatalf("expected repaired go:embed placement, got:\n%s", formatted)
+	}
+}
+
+func TestIsEmbedDirectiveTextRejectsInvalidPrefixes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{
+			name: "space separated directive",
+			text: "//go:embed foo.txt",
+			want: true,
+		},
+		{
+			name: "tab separated directive",
+			text: "//go:embed\tfoo.txt",
+			want: true,
+		},
+		{
+			name: "bare directive",
+			text: "//go:embed",
+			want: false,
+		},
+		{
+			name: "embedded prefix",
+			text: "//go:embedded foo.txt",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isEmbedDirectiveText(tt.text); got != tt.want {
+				t.Fatalf("isEmbedDirectiveText(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyReordersTypesWithoutEmbedDirective(t *testing.T) {
 	path := writeTempGoFile(t, `package sample
 

--- a/semantic/rules/declaration_order/rule.go
+++ b/semantic/rules/declaration_order/rule.go
@@ -165,7 +165,7 @@ func collapseEmbedSpacing(src []byte) []byte {
 			continue
 		}
 
-		if !bytes.HasPrefix(bytes.TrimSpace(lines[i]), []byte("//go:embed ")) {
+		if !isEmbedDirectiveLine(lines[i]) {
 			continue
 		}
 
@@ -181,6 +181,25 @@ func collapseEmbedSpacing(src []byte) []byte {
 	}
 
 	return bytes.Join(out, []byte{'\n'})
+}
+
+func isEmbedDirectiveLine(line []byte) bool {
+	return hasEmbedDirectiveLinePrefix(bytes.TrimSpace(line))
+}
+
+func hasEmbedDirectiveLinePrefix(line []byte) bool {
+	const prefix = "//go:embed"
+
+	if !bytes.HasPrefix(line, []byte(prefix)) || len(line) == len(prefix) {
+		return false
+	}
+
+	switch line[len(prefix)] {
+	case ' ', '\t':
+		return true
+	default:
+		return false
+	}
 }
 
 func isVarDeclStart(line []byte) bool {

--- a/semantic/rules/declaration_order/rule_test.go
+++ b/semantic/rules/declaration_order/rule_test.go
@@ -224,6 +224,46 @@ type runtime struct{}
 	}
 }
 
+func TestApplyPreservesGoEmbedAdjacencyWithTab(t *testing.T) {
+	path := writeTempGoFile(t, "package sample\n\nimport \"embed\"\n\n//go:embed\tfoo.txt\n\ntype runtime struct{}\n\nvar rootTemplateFS embed.FS\n")
+
+	violations, formatted, err := New().Apply(path, mustReadFile(t, path))
+
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	expected := "package sample\n\nimport \"embed\"\n\n//go:embed\tfoo.txt\nvar rootTemplateFS embed.FS\n\ntype runtime struct{}\n"
+
+	if !bytes.Equal(formatted, []byte(expected)) {
+		t.Fatalf("expected embed directive repair output, got:\n%s", formatted)
+	}
+}
+
+func TestApplyLeavesOrderedGoEmbedDirectiveWithTabUnchanged(t *testing.T) {
+	path := writeTempGoFile(t, "package sample\n\nimport \"embed\"\n\n//go:embed\tfoo.txt\nvar rootTemplateFS embed.FS\n\ntype runtime struct{}\n")
+
+	input := mustReadFile(t, path)
+
+	violations, formatted, err := New().Apply(path, input)
+
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %d", len(violations))
+	}
+
+	if !bytes.Equal(formatted, input) {
+		t.Fatalf("expected already attached go:embed declaration to remain unchanged, got:\n%s", formatted)
+	}
+}
+
 func TestCollapseEmbedSpacingRecognizesVarForms(t *testing.T) {
 	t.Parallel()
 
@@ -295,6 +335,41 @@ type runtime struct{}
 //go:embed foo.txt
 
 type runtime struct{}
+`,
+		},
+		{
+			name:     "tab separated directive",
+			src:      "package sample\n\n//go:embed\tfoo.txt\n\nvar rootTemplateFS embed.FS\n",
+			expected: "package sample\n\n//go:embed\tfoo.txt\nvar rootTemplateFS embed.FS\n",
+		},
+		{
+			name: "bare directive",
+			src: `package sample
+
+//go:embed
+
+var rootTemplateFS embed.FS
+`,
+			expected: `package sample
+
+//go:embed
+
+var rootTemplateFS embed.FS
+`,
+		},
+		{
+			name: "embedded prefix",
+			src: `package sample
+
+//go:embedded foo.txt
+
+var rootTemplateFS embed.FS
+`,
+			expected: `package sample
+
+//go:embedded foo.txt
+
+var rootTemplateFS embed.FS
 `,
 		},
 		{


### PR DESCRIPTION
## Summary
- make the active spacing rule treat `//go:embed` directives as anchored to the following top-level `var` declaration
- preserve existing top-level type reordering for normal files while preventing directive-bound vars from being separated
- normalize emitted spacing so `//go:embed` stays immediately above its target declaration
- add rule-level and formatter-level regression coverage for detached and already-correct `go:embed` layouts

## Testing
- `go test ./packages/formatter/rules/spacing`
- `go test ./packages/formatter`