### PR TITLE
chore(release): connect go-fmt container image to its source repo

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -93,19 +93,6 @@ jobs:
                       "${IMAGE_NAME}@${DIGEST}"
               shell: bash
 
-            - name: Ensure GHCR package is public
-              env:
-                  GH_TOKEN: ${{ secrets.GHCR_VISIBILITY_TOKEN }}
-              run: |
-                  set -euo pipefail
-
-                  gh api \
-                      --method PATCH \
-                      -H "Accept: application/vnd.github+json" \
-                      /orgs/oullin/packages/container/go-fmt \
-                      -f visibility=public
-              shell: bash
-
             - name: Create or update release
               uses: softprops/action-gh-release@v2
               with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -93,6 +93,19 @@ jobs:
                       "${IMAGE_NAME}@${DIGEST}"
               shell: bash
 
+            - name: Ensure GHCR package is public
+              env:
+                  GH_TOKEN: ${{ secrets.GHCR_VISIBILITY_TOKEN }}
+              run: |
+                  set -euo pipefail
+
+                  gh api \
+                      --method PATCH \
+                      -H "Accept: application/vnd.github+json" \
+                      /orgs/oullin/packages/container/go-fmt \
+                      -f visibility=public
+              shell: bash
+
             - name: Create or update release
               uses: softprops/action-gh-release@v2
               with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,5 +47,8 @@ COPY --from=builder /out/go-fmt /usr/local/bin/go-fmt
 COPY --from=builder /out/gofmt /usr/local/bin/gofmt
 COPY --from=builder /out/goimports /usr/local/bin/goimports
 
+LABEL org.opencontainers.image.source="https://github.com/oullin/go-fmt" \
+	org.opencontainers.image.description="go-fmt formatter container"
+
 ENTRYPOINT ["/usr/local/bin/go-fmt"]
 CMD ["help"]


### PR DESCRIPTION
## Summary

Adds the standard OCI labels (\`org.opencontainers.image.source\` + \`description\`) to the released container image so the GHCR package page is connected to this repo. That connection enables the **Inherit access from source repository** affordance in the GHCR UI and gives every consumer a clickable link from the package back to source.

## Background — why this is a labels-only PR

The original goal was to make \`ghcr.io/oullin/go-fmt\` publicly pullable so consumers (e.g. \`git-diff\` whose \`make format\` currently fails with \`image ghcr.io/oullin/go-fmt:v0.0.19 ... denied\`) don't need \`docker login ghcr.io\` and a \`read:packages\` PAT.

I attempted to automate the visibility flip from \`publish-release.yml\` (REST \`PATCH /orgs/oullin/packages/container/go-fmt\`). It failed in CI with \`404 Not Found\`. Investigation:

- **REST API**: that route only supports \`GET\` and \`DELETE\` on org-owned packages — no visibility mutation exists.
- **GraphQL API**: schema introspection shows the only package mutation is \`deletePackageVersion\`. No \`updatePackage\`, no visibility mutation.

GitHub does not expose a programmatic path. Visibility must be set once in the UI by an org owner at <https://github.com/orgs/oullin/packages/container/go-fmt/settings> → **Change visibility → Public**. The setting is sticky across every existing tag and every future push, so it's a one-time action — no per-release automation needed.

The \`GHCR_VISIBILITY_TOKEN\` org secret added during this work can be deleted; it has no consumer.

## What this PR actually changes

- \`Dockerfile\`: \`LABEL org.opencontainers.image.source\` + \`org.opencontainers.image.description\` on the final stage.

(The intermediate commit that added/removed the workflow step is preserved in history for the record.)

## Test plan

- [ ] Org owner flips visibility to **Public** at the settings URL above.
- [ ] \`curl -sI https://ghcr.io/v2/oullin/go-fmt/manifests/v0.0.19\` returns \`200 OK\`.
- [ ] \`docker logout ghcr.io && docker pull ghcr.io/oullin/go-fmt:v0.0.19\` succeeds from a clean shell.
- [ ] Next release (or \`workflow_dispatch\` re-run of publish-release.yml against a tag) produces an image whose GHCR page shows the **Connected to repository** badge linking to \`oullin/go-fmt\`.
- [ ] In \`git-diff\`, \`make format\` succeeds with no \`make format-login\` first.