### PR TITLE
Fix fmt-ts release verification for mounted Git worktrees

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
+            - name: Shell - Run entrypoint tests
+              run: ./scripts/test-entrypoints.sh
+
             - uses: actions/setup-go@v6
               with:
                   go-version-file: go.work

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,9 @@ jobs:
             - uses: actions/checkout@v6
               name: Checkout repository
 
+            - name: Shell - Run entrypoint tests
+              run: ./scripts/test-entrypoints.sh
+
             - uses: actions/setup-go@v6
               name: Install Go
               with:

--- a/cmd/fmt-ts
+++ b/cmd/fmt-ts
@@ -11,6 +11,8 @@ if [[ ${#args[@]} -eq 0 ]]; then
 	args=(.)
 fi
 
+git config --global --add safe.directory "$PWD" >/dev/null 2>&1 || true
+
 "$tsx_bin" "${support_dir}/blank-lines.ts" "${args[@]}"
 
 git ls-files --cached --others --exclude-standard -z -- "${args[@]}" \

--- a/cmd/fmt-ts
+++ b/cmd/fmt-ts
@@ -11,7 +11,9 @@ if [[ ${#args[@]} -eq 0 ]]; then
 	args=(.)
 fi
 
-git config --global --add safe.directory "$PWD" >/dev/null 2>&1 || true
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=safe.directory
+export GIT_CONFIG_VALUE_0="*"
 
 "$tsx_bin" "${support_dir}/blank-lines.ts" "${args[@]}"
 

--- a/scripts/test-entrypoints.sh
+++ b/scripts/test-entrypoints.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"${script_dir}/test-fmt-all-entrypoint.sh"
+"${script_dir}/test-fmt-ts-entrypoint.sh"

--- a/scripts/test-fmt-ts-entrypoint.sh
+++ b/scripts/test-fmt-ts-entrypoint.sh
@@ -29,6 +29,7 @@ write_executable() {
 write_executable "$bin_dir/git" '#!/usr/bin/env bash
 set -euo pipefail
 printf "git %s\n" "$*" >> "'"$log_file"'"
+printf "git-config %s %s %s\n" "${GIT_CONFIG_COUNT:-}" "${GIT_CONFIG_KEY_0:-}" "${GIT_CONFIG_VALUE_0:-}" >> "'"$log_file"'"
 if [[ "${1:-}" == "config" ]]; then
 	exit 0
 fi
@@ -41,7 +42,8 @@ exit 1'
 
 write_executable "$support_dir/node_modules/.bin/tsx" '#!/usr/bin/env bash
 set -euo pipefail
-printf "tsx %s\n" "$*" >> "'"$log_file"'"'
+printf "tsx %s\n" "$*" >> "'"$log_file"'"
+printf "tsx-config %s %s %s\n" "${GIT_CONFIG_COUNT:-}" "${GIT_CONFIG_KEY_0:-}" "${GIT_CONFIG_VALUE_0:-}" >> "'"$log_file"'"'
 
 write_executable "$support_dir/node_modules/.bin/oxfmt" '#!/usr/bin/env bash
 set -euo pipefail
@@ -59,7 +61,7 @@ touch "$support_dir/blank-lines.ts"
 		"$repo_root/cmd/fmt-ts" .
 )
 
-expected=$'git config --global --add safe.directory '"$workdir"$'\ntsx '"$support_dir"$'/blank-lines.ts .\ngit ls-files --cached --others --exclude-standard -z -- .\noxfmt --write --no-error-on-unmatched-pattern sample.ts'
+expected=$'tsx '"$support_dir"$'/blank-lines.ts .\ntsx-config 1 safe.directory *\ngit ls-files --cached --others --exclude-standard -z -- .\ngit-config 1 safe.directory *\noxfmt --write --no-error-on-unmatched-pattern sample.ts'
 actual="$(<"$log_file")"
 
 if [[ "$actual" != "$expected" ]]; then

--- a/scripts/test-fmt-ts-entrypoint.sh
+++ b/scripts/test-fmt-ts-entrypoint.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tmp_root="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$tmp_root"
+}
+
+trap cleanup EXIT
+
+support_dir="$tmp_root/support"
+bin_dir="$tmp_root/bin"
+workdir="$tmp_root/work"
+log_file="$tmp_root/invocations.log"
+
+mkdir -p "$support_dir/node_modules/.bin" "$bin_dir" "$workdir"
+: >"$log_file"
+
+write_executable() {
+	local path="$1"
+	local body="$2"
+
+	printf '%s\n' "$body" >"$path"
+	chmod +x "$path"
+}
+
+write_executable "$bin_dir/git" '#!/usr/bin/env bash
+set -euo pipefail
+printf "git %s\n" "$*" >> "'"$log_file"'"
+if [[ "${1:-}" == "config" ]]; then
+	exit 0
+fi
+if [[ "${1:-}" == "ls-files" ]]; then
+	printf "sample.ts\0"
+	exit 0
+fi
+printf "unexpected git command: %s\n" "$*" >&2
+exit 1'
+
+write_executable "$support_dir/node_modules/.bin/tsx" '#!/usr/bin/env bash
+set -euo pipefail
+printf "tsx %s\n" "$*" >> "'"$log_file"'"'
+
+write_executable "$support_dir/node_modules/.bin/oxfmt" '#!/usr/bin/env bash
+set -euo pipefail
+printf "oxfmt %s\n" "$*" >> "'"$log_file"'"
+while IFS= read -r -d "" file; do
+	printf "oxfmt-file %s\n" "$file" >> "'"$log_file"'"
+done'
+
+touch "$support_dir/blank-lines.ts"
+
+(
+	cd "$workdir"
+	PATH="$bin_dir:$PATH" \
+		GO_FMT_SUPPORT_DIR="$support_dir" \
+		"$repo_root/cmd/fmt-ts" .
+)
+
+expected=$'git config --global --add safe.directory '"$workdir"$'\ntsx '"$support_dir"$'/blank-lines.ts .\ngit ls-files --cached --others --exclude-standard -z -- .\noxfmt --write --no-error-on-unmatched-pattern sample.ts'
+actual="$(<"$log_file")"
+
+if [[ "$actual" != "$expected" ]]; then
+	printf 'unexpected invocation log\nexpected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary
- Add Git `safe.directory` setup to `cmd/fmt-ts` so the Node/TS image can format mounted repos without failing on dubious ownership.
- Add focused entrypoint coverage for `fmt-ts`, plus a small wrapper to run both shell entrypoint tests.
- Run the entrypoint tests in both PR and release workflows so this regression is caught before publishing.

## Testing
- Added shell coverage for the `fmt-ts` entrypoint safe-directory path.
- Verified the entrypoint test suite locally.
- Verified the Node/TS release image builds and formats a mounted temp Git repo successfully.