### PR TITLE
Fix Codecov badge by publishing main branch coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 
 on:
+    push:
+        branches:
+            - main
     pull_request:
         branches:
             - main
@@ -16,7 +19,7 @@ env:
 
 jobs:
     check:
-        if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main'
+        if: github.event_name == 'push' || (github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main')
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
@@ -117,4 +120,5 @@ jobs:
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: packages/formatter/coverage.out
+                  override_branch: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
                   fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go 1.25](https://img.shields.io/badge/go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev/doc/go1.25)
 [![Tests](https://github.com/oullin/go-fmt/actions/workflows/tests.yml/badge.svg)](https://github.com/oullin/go-fmt/actions/workflows/tests.yml)
 [![Release](https://github.com/oullin/go-fmt/actions/workflows/release.yml/badge.svg)](https://github.com/oullin/go-fmt/actions/workflows/release.yml)
-[![Codecov](https://codecov.io/gh/oullin/go-fmt/graph/badge.svg?branch=main)](https://codecov.io/gh/oullin/go-fmt)
+[![Codecov](https://codecov.io/gh/oullin/go-fmt/graph/badge.svg?branch=main)](https://app.codecov.io/github/oullin/go-fmt)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io%2Foullin%2Fgo--fmt-2496ED?logo=docker&logoColor=white)](https://github.com/oullin/go-fmt/pkgs/container/go-fmt)
 
 **Rule-driven formatting for Go, runnable as a CLI or a single shared container.**


### PR DESCRIPTION
## Summary
- Add `push` coverage runs for `main` so Codecov receives data for the default branch.
- Make the Codecov upload step branch-aware for both `pull_request` and `push` events.
- Update the README badge link to the current Codecov app URL.

## Testing
- Workflow syntax validated with `actionlint`.
- Confirmed the badge URL and upload configuration are wired to `main` coverage.
- Not run (not requested): end-to-end GitHub Actions execution on `main` after merge.