### PR TITLE
fix: verify node-ts image lacks Go toolchain via entrypoint override

### DIFF
--- a/scripts/release-image/node-ts.sh
+++ b/scripts/release-image/node-ts.sh
@@ -12,7 +12,7 @@ verify_node_ts_image() {
 	release_image_run_in_workdir "$tmpdir" "$image" .
 	assert_file_contains "${tmpdir}/sample.ts" 'const value = { name: "demo" };'
 
-	if release_image_run "$image" go version >/dev/null 2>&1; then
-		release_image_fail "node-ts image unexpectedly accepts Go CLI commands: ${image}"
+	if docker run --rm --entrypoint sh "$image" -c 'command -v go' >/dev/null 2>&1; then
+		release_image_fail "node-ts image unexpectedly ships a Go toolchain: ${image}"
 	fi
 }

--- a/scripts/release-image/node-ts.sh
+++ b/scripts/release-image/node-ts.sh
@@ -12,7 +12,7 @@ verify_node_ts_image() {
 	release_image_run_in_workdir "$tmpdir" "$image" .
 	assert_file_contains "${tmpdir}/sample.ts" 'const value = { name: "demo" };'
 
-	if docker run --rm --entrypoint sh "$image" -c 'command -v go' >/dev/null 2>&1; then
+	if release_image_run --entrypoint sh "$image" -c 'command -v go' >/dev/null 2>&1; then
 		release_image_fail "node-ts image unexpectedly ships a Go toolchain: ${image}"
 	fi
 }


### PR DESCRIPTION
## Summary

- Fixes the `v0.2.4` Publish Release failure where the verifier reported `node-ts image unexpectedly accepts Go CLI commands` ([run 26560965740](https://github.com/oullin/go-fmt/actions/runs/26560965740/job/78243878139)).
- Replaces the indirect `fmt-ts go version` probe with a direct `command -v go` check using `--entrypoint sh`.

## Why

`scripts/release-image/node-ts.sh` was relying on the `fmt-ts` entrypoint to reject `go version` as positional args (the old `git ls-files` pipeline exited non-zero outside a git repo). PR #33 swapped that pipeline for the new `fmt-sources` Go binary, which intentionally treats missing scopes as warnings ([sourcefiles.go:49-54](https://github.com/oullin/go-fmt/blob/main/packages/driver/internal/sourcefiles/sourcefiles.go#L49-L54), covered by [sourcefiles_test.go:93-117](https://github.com/oullin/go-fmt/blob/main/packages/driver/internal/sourcefiles/sourcefiles_test.go#L93-L117)). With both `go` and `version` skipped, the entrypoint exits 0 and the assertion fires.

The build/push steps and the images themselves are fine; only the verification logic was stale. Probing `command -v go` directly maps to the real isolation guarantee (final stage is `FROM node:25.8.2-alpine`, no Go toolchain) and doesn't depend on entrypoint arg handling.

## Test plan

- [x] `docker pull ghcr.io/oullin/go-fmt:v0.2.4-node-ts && docker run --rm --entrypoint sh ghcr.io/oullin/go-fmt:v0.2.4-node-ts -c 'command -v go'` → exits 127 (no `go` on PATH), so the new probe passes.
- [x] `IMAGE_NAME=ghcr.io/oullin/go-fmt NEW_TAG=v0.2.4 ./scripts/verify-release-image.sh` runs all three image checks without firing `release_image_fail`.
- [ ] After merge: trigger `Publish Release` workflow_dispatch with `tag=v0.2.4` and confirm it goes green end-to-end (images are already pushed; concurrency group permits a safe retry).