### PR TITLE
test: raise formatter coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,20 @@ If `fmt-go` is not on your `PATH` after `go install`, add the Go bin directory: 
 
 ## Usage
 
-| Command            | What it does                              |
-| ------------------ | ----------------------------------------- |
-| `check [paths...]` | Reports violations without writing.       |
-| `format [paths...]`| Rewrites files in place.                  |
+| Command             | What it does                        |
+| ------------------- | ----------------------------------- |
+| `check [paths...]`  | Reports violations without writing. |
+| `format [paths...]` | Rewrites files in place.            |
 
 Both default to `.` when no paths are given. Both run `go vet ./...` automatically when the working directory is inside a Go module or workspace.
 
-| Flag         | Default | Description                                                          |
-| ------------ | ------- | -------------------------------------------------------------------- |
-| `--config`   | auto    | Path to a `config.yml`. Auto-detected if omitted.                    |
-| `--cwd`      | `.`     | Base path for config discovery and relative output paths.            |
-| `--format`   | `text`  | Output mode: `text`, `json`, or `agent`.                             |
-| `--jobs`     | `0`     | Max files in parallel; `0` uses `runtime.NumCPU()`. Reads `GO_FMT_JOBS`. |
-| `--host-path`| off     | Absolute host path under `HOST_PROJECT_PATH` (Docker host-mount flow).|
+| Flag          | Default | Description                                                              |
+| ------------- | ------- | ------------------------------------------------------------------------ |
+| `--config`    | auto    | Path to a `config.yml`. Auto-detected if omitted.                        |
+| `--cwd`       | `.`     | Base path for config discovery and relative output paths.                |
+| `--format`    | `text`  | Output mode: `text`, `json`, or `agent`.                                 |
+| `--jobs`      | `0`     | Max files in parallel; `0` uses `runtime.NumCPU()`. Reads `GO_FMT_JOBS`. |
+| `--host-path` | off     | Absolute host path under `HOST_PROJECT_PATH` (Docker host-mount flow).   |
 
 A handful of common invocations:
 
@@ -98,16 +98,16 @@ not_name:
 concurrency: 0
 ```
 
-| Field                   | Type | Default                          | Description                                  |
-| ----------------------- | ---- | -------------------------------- | -------------------------------------------- |
-| `rules.spacing.enabled` | bool | `true`                           | Enables the spacing rule.                    |
-| `vet.enabled`           | bool | `true`                           | Runs `go vet ./...` after formatting.        |
-| `formatters.gofmt`      | bool | `true`                           | Runs `gofmt` after the rules.                |
-| `formatters.goimports`  | bool | `true`                           | Runs `goimports` after `gofmt`.              |
-| `exclude`               | list | `.git`, `node_modules`, `vendor` | Directory names skipped during traversal.    |
-| `not_path`              | list | empty                            | Substrings matched against full file paths.  |
-| `not_name`              | list | empty                            | Globs matched against file names.            |
-| `concurrency`           | int  | `0`                              | Max files in parallel (`0` = `NumCPU`).      |
+| Field                   | Type | Default                          | Description                                 |
+| ----------------------- | ---- | -------------------------------- | ------------------------------------------- |
+| `rules.spacing.enabled` | bool | `true`                           | Enables the spacing rule.                   |
+| `vet.enabled`           | bool | `true`                           | Runs `go vet ./...` after formatting.       |
+| `formatters.gofmt`      | bool | `true`                           | Runs `gofmt` after the rules.               |
+| `formatters.goimports`  | bool | `true`                           | Runs `goimports` after `gofmt`.             |
+| `exclude`               | list | `.git`, `node_modules`, `vendor` | Directory names skipped during traversal.   |
+| `not_path`              | list | empty                            | Substrings matched against full file paths. |
+| `not_name`              | list | empty                            | Globs matched against file names.           |
+| `concurrency`           | int  | `0`                              | Max files in parallel (`0` = `NumCPU`).     |
 
 ## What it formats
 
@@ -123,13 +123,13 @@ Full catalogue with before/after examples: [docs/spacing.md](docs/spacing.md).
 
 When given directories, the engine walks recursively for `.go` files and always skips:
 
-| Skipped                              | Reason                                  |
-| ------------------------------------ | --------------------------------------- |
-| Hidden directories                   | Convention, not source code.            |
-| `.git/`, `vendor/`                   | Repository and dependency metadata.     |
-| `*.gen.go`                           | Generated code by convention.           |
-| Files starting `// Code generated`   | Go's standard generated-file marker.    |
-| `exclude` / `not_path` / `not_name`  | User-defined exclusions.                |
+| Skipped                             | Reason                               |
+| ----------------------------------- | ------------------------------------ |
+| Hidden directories                  | Convention, not source code.         |
+| `.git/`, `vendor/`                  | Repository and dependency metadata.  |
+| `*.gen.go`                          | Generated code by convention.        |
+| Files starting `// Code generated`  | Go's standard generated-file marker. |
+| `exclude` / `not_path` / `not_name` | User-defined exclusions.             |
 
 ## Output formats
 
@@ -149,19 +149,17 @@ When given directories, the engine walks recursively for `.go` files and always 
 
 ```json
 {
-    "result": "fail",
-    "files": 1,
-    "changed": 1,
-    "results": [
-        {
-            "file": "main.go",
-            "applied": ["spacing"],
-            "violations": [
-                { "rule": "spacing", "line": 5, "message": "missing blank line before if statement" }
-            ],
-            "changed": true
-        }
-    ]
+	"result": "fail",
+	"files": 1,
+	"changed": 1,
+	"results": [
+		{
+			"file": "main.go",
+			"applied": ["spacing"],
+			"violations": [{ "rule": "spacing", "line": 5, "message": "missing blank line before if statement" }],
+			"changed": true
+		}
+	]
 }
 ```
 
@@ -169,12 +167,10 @@ When given directories, the engine walks recursively for `.go` files and always 
 
 ```json
 {
-    "result": "fail",
-    "summary": { "files": 1, "changed": 1, "violations": 1 },
-    "changed": [{ "file": "main.go", "steps": ["spacing"] }],
-    "violations": [
-        { "file": "main.go", "rule": "spacing", "line": 5, "message": "missing blank line before if statement" }
-    ]
+	"result": "fail",
+	"summary": { "files": 1, "changed": 1, "violations": 1 },
+	"changed": [{ "file": "main.go", "steps": ["spacing"] }],
+	"violations": [{ "file": "main.go", "rule": "spacing", "line": 5, "message": "missing blank line before if statement" }]
 }
 ```
 
@@ -182,12 +178,12 @@ When given directories, the engine walks recursively for `.go` files and always 
 
 Published to `ghcr.io/oullin/go-fmt` for `linux/amd64` and `linux/arm64`.
 
-| Tag                              | Contents                              | Entrypoint |
-| -------------------------------- | ------------------------------------- | ---------- |
-| `latest`, `<tag>`                | Full Go + TS/Vue formatter (alias).   | `fmt-all`  |
-| `latest-full`, `<tag>-full`      | Full Go + TS/Vue formatter.           | `fmt-all`  |
-| `latest-go`, `<tag>-go`          | Go formatter CLI only.                | `fmt-go`   |
-| `latest-node-ts`, `<tag>-node-ts`| TS/Vue formatter only.                | `fmt-ts`   |
+| Tag                               | Contents                            | Entrypoint |
+| --------------------------------- | ----------------------------------- | ---------- |
+| `latest`, `<tag>`                 | Full Go + TS/Vue formatter (alias). | `fmt-all`  |
+| `latest-full`, `<tag>-full`       | Full Go + TS/Vue formatter.         | `fmt-all`  |
+| `latest-go`, `<tag>-go`           | Go formatter CLI only.              | `fmt-go`   |
+| `latest-node-ts`, `<tag>-node-ts` | TS/Vue formatter only.              | `fmt-ts`   |
 
 ## Exit codes
 

--- a/packages/formatter/rules/spacing/spacing_internal_test.go
+++ b/packages/formatter/rules/spacing/spacing_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"strings"
 	"testing"
 )
 
@@ -24,8 +25,6 @@ func TestStatementLabelControlStatements(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			if got := statementLabel(tt.stmt, nil); got != tt.want {
 				t.Fatalf("expected %q, got %q", tt.want, got)
@@ -51,8 +50,6 @@ func TestAssignedIdentifierBranches(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := assignedIdentifier(tt.stmt)
 
@@ -70,6 +67,221 @@ func TestSpansMultipleLinesNilInputs(t *testing.T) {
 
 	if spansMultipleLines(firstStmt(t, "return"), nil) {
 		t.Fatal("expected nil fileset to be single-line")
+	}
+}
+
+func TestRouteRegistryCallLabelBranches(t *testing.T) {
+	tests := []struct {
+		name string
+		stmt ast.Stmt
+		want string
+		ok   bool
+	}{
+		{name: "routes add", stmt: firstStmt(t, `routes.Add("home")`), want: "routes call", ok: true},
+		{name: "routes group", stmt: firstStmt(t, `routes.Group("home")`), want: "routes call", ok: true},
+		{name: "other routes method", stmt: firstStmt(t, `routes.Delete("home")`), ok: false},
+		{name: "other receiver", stmt: firstStmt(t, `router.Add("home")`), ok: false},
+		{name: "not selector", stmt: firstStmt(t, `println("home")`), ok: false},
+		{name: "selector expression receiver", stmt: firstStmt(t, `app.routes.Add("home")`), ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := routeRegistryCallLabel(tt.stmt)
+
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("expected (%q, %v), got (%q, %v)", tt.want, tt.ok, got, ok)
+			}
+		})
+	}
+}
+
+func TestSelectorReceiverNameBranches(t *testing.T) {
+	aliases := importAliases{
+		"ordered": "slices",
+		"random":  "math/rand/v2",
+	}
+
+	tests := []struct {
+		name string
+		stmt ast.Stmt
+		want string
+		ok   bool
+	}{
+		{name: "stdlib receiver", stmt: firstStmt(t, `sort.Strings(values)`), want: "sort", ok: true},
+		{name: "aliased slices sort", stmt: firstStmt(t, `ordered.Sort(values)`), want: "ordered", ok: true},
+		{name: "aliased rand", stmt: firstStmt(t, `random.Int()`), want: "random", ok: true},
+		{name: "unknown selector", stmt: firstStmt(t, `logger.Info()`), ok: false},
+		{name: "selector expression receiver", stmt: firstStmt(t, `pkg.sort.Strings(values)`), ok: false},
+		{name: "not selector call", stmt: firstStmt(t, `println("home")`), ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := selectorReceiverName(tt.stmt, aliases)
+
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("expected (%q, %v), got (%q, %v)", tt.want, tt.ok, got, ok)
+			}
+		})
+	}
+}
+
+func TestSelectorCallBranches(t *testing.T) {
+	if _, ok := selectorCall(&ast.ReturnStmt{}); ok {
+		t.Fatal("expected non-expression statement to be rejected")
+	}
+
+	if _, ok := selectorCall(&ast.ExprStmt{X: &ast.SelectorExpr{}}); ok {
+		t.Fatal("expected selector expression without call to be rejected")
+	}
+
+	if _, ok := selectorCall(&ast.ExprStmt{X: &ast.CallExpr{Fun: &ast.Ident{Name: "println"}}}); ok {
+		t.Fatal("expected non-selector call to be rejected")
+	}
+}
+
+func TestBuildImportAliasesSkipsUnsupportedNames(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "sample.go", `package sample
+
+import (
+	. "sort"
+	_ "slices"
+	random "math/rand/v2"
+	"fmt"
+)
+`, parser.ParseComments)
+
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	aliases := buildImportAliases(file)
+
+	if len(aliases) != 1 || aliases["random"] != "math/rand/v2" {
+		t.Fatalf("unexpected aliases: %#v", aliases)
+	}
+}
+
+func TestContainsEmbedDirectiveNilAndMultipleComments(t *testing.T) {
+	if containsEmbedDirective(nil) {
+		t.Fatal("expected nil group to not contain embed directive")
+	}
+
+	group := &ast.CommentGroup{
+		List: []*ast.Comment{
+			{Text: "// ordinary comment"},
+			{Text: "//go:embed fixtures/*.txt"},
+		},
+	}
+
+	if !containsEmbedDirective(group) {
+		t.Fatal("expected embed directive to be detected")
+	}
+
+	withoutEmbed := &ast.CommentGroup{
+		List: []*ast.Comment{
+			{Text: "// ordinary comment"},
+			{Text: "//go:generate echo ok"},
+		},
+	}
+
+	if containsEmbedDirective(withoutEmbed) {
+		t.Fatal("expected ordinary comments to not contain embed directive")
+	}
+}
+
+func TestEmbedDirectiveLinePrefixEdges(t *testing.T) {
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{line: "//go:embed fixtures/*.txt", want: true},
+		{line: "//go:embed\tfixtures/*.txt", want: true},
+		{line: "//go:embed", want: false},
+		{line: "//go:embedded fixtures/*.txt", want: false},
+		{line: "//go:embed-fixtures", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			if got := hasEmbedDirectiveLinePrefix([]byte(tt.line)); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDeclOrdersEqualBranches(t *testing.T) {
+	orderedFile, err := parser.ParseFile(token.NewFileSet(), "sample.go", `package sample
+
+type config struct{}
+
+func run() {}
+`, parser.ParseComments)
+
+	if err != nil {
+		t.Fatalf("parse ordered source: %v", err)
+	}
+
+	if !declOrdersEqual(orderedFile.Decls, orderedFile.Decls) {
+		t.Fatal("expected identical declaration order to match")
+	}
+
+	reversed := []ast.Decl{orderedFile.Decls[1], orderedFile.Decls[0]}
+
+	if declOrdersEqual(orderedFile.Decls, reversed) {
+		t.Fatal("expected reordered declarations to differ")
+	}
+
+	if declOrdersEqual(orderedFile.Decls, orderedFile.Decls[:1]) {
+		t.Fatal("expected declaration slices with different lengths to differ")
+	}
+}
+
+func TestNextTopLevelVarDeclAfterMissing(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "sample.go", `package sample
+
+var one = 1
+var two = 2
+`, parser.ParseComments)
+
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	decls := topLevelVarDecls(file)
+
+	if len(decls) != 2 {
+		t.Fatalf("expected 2 var declarations, got %d", len(decls))
+	}
+
+	if _, ok := nextTopLevelVarDeclAfter(decls, decls[1].Pos()); ok {
+		t.Fatal("expected no var declaration after the final var")
+	}
+}
+
+func TestIsVarDeclStartEdges(t *testing.T) {
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{line: "var", want: true},
+		{line: "var\troot embed.FS", want: true},
+		{line: "var\n", want: true},
+		{line: "var\r", want: true},
+		{line: "var\f", want: true},
+		{line: "var\v", want: true},
+		{line: "varName := true", want: false},
+		{line: "variant := true", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(strings.ReplaceAll(tt.line, "\n", "\\n"), func(t *testing.T) {
+			if got := isVarDeclStart([]byte(tt.line)); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
 	}
 }
 

--- a/packages/formatter/rules/spacing/spacing_test.go
+++ b/packages/formatter/rules/spacing/spacing_test.go
@@ -86,6 +86,35 @@ func run(v int) {
 	}
 }
 
+func TestApplyChecksSelectCommunicationBodies(t *testing.T) {
+	path := writeTempGoFile(t, `package sample
+
+func run(ch <-chan int) {
+	select {
+	case value := <-ch:
+		if value > 0 {
+			println(value)
+		}
+		println("next")
+	}
+}
+`)
+
+	violations, formatted, err := New().Apply(path, mustReadFile(t, path))
+
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+
+	if !strings.Contains(string(formatted), "}\n\n\t\tprintln(\"next\")") {
+		t.Fatalf("expected blank line inside select communication body, got:\n%s", formatted)
+	}
+}
+
 func TestApplyFindsVarSpacing(t *testing.T) {
 	path := writeTempGoFile(t, `package sample
 
@@ -1175,6 +1204,54 @@ type runtime struct{}
 	}
 }
 
+func TestApplyRepairsMultipleDetachedGoEmbedDirectives(t *testing.T) {
+	path := writeTempGoFile(t, `package sample
+
+import "embed"
+
+//go:embed first.txt
+
+type runtime struct{}
+
+var firstFS embed.FS
+
+//go:embed second.txt
+
+func run() {}
+
+var secondFS embed.FS
+`)
+
+	violations, formatted, err := New().Apply(path, mustReadFile(t, path))
+
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d", len(violations))
+	}
+
+	expected := `package sample
+
+import "embed"
+
+//go:embed first.txt
+var firstFS embed.FS
+
+type runtime struct{}
+
+//go:embed second.txt
+var secondFS embed.FS
+
+func run() {}
+`
+
+	if string(formatted) != expected {
+		t.Fatalf("expected repaired go:embed placements, got:\n%s", formatted)
+	}
+}
+
 func TestApplyKeepsAttachedGoEmbedDirectiveUnchanged(t *testing.T) {
 	path := writeTempGoFile(t, `package sample
 
@@ -1259,8 +1336,6 @@ func TestApplyPreservesImportsBeforeAnchoredDecls(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1316,8 +1391,6 @@ func TestIsEmbedDirectiveTextRejectsInvalidPrefixes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1522,8 +1595,6 @@ type config struct{}
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			file, err := parser.ParseFile(token.NewFileSet(), "sample.go", tt.src, parser.ParseComments)
 
@@ -1562,8 +1633,6 @@ func TestCollapseEmbedSpacingVarDeclStarts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			if got := string(collapseEmbedSpacing([]byte(tt.src))); got != tt.want {
 				t.Fatalf("unexpected collapsed source:\n%s", got)


### PR DESCRIPTION
## Summary
- format README.md with the existing devx formatter path so the devx check passes
- add focused formatter spacing tests for select bodies, go:embed repair, selector helpers, declaration order, and directive edge cases
- raise local formatter Go coverage to 94.9% to give Codecov room above the 90% target

## Validation
- ./scripts/with-storage-env.sh pnpm turbo run check --cache-dir=storage/.cache/turbo --filter=devx
- ./scripts/with-storage-env.sh go -C packages/formatter test ./... -coverprofile=coverage.out -covermode=atomic
- go -C packages/formatter tool cover -func=coverage.out
- ./scripts/test-coverage.sh
