### PR TITLE
feat: ship bundled .oxfmtrc.json and apply it in userland

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ concurrency: 0
 | `not_name`              | list | empty                            | Globs matched against file names.           |
 | `concurrency`           | int  | `0`                              | Max files in parallel (`0` = `NumCPU`).     |
 
+### TS/Vue formatting (`.oxfmtrc.json`)
+
+The TS/Vue layer runs [`oxfmt`](https://www.npmjs.com/package/oxfmt) over your sources. The images ship a bundled `.oxfmtrc.json` (tabs, single quotes, trailing commas, 200-column width) that is applied by default, so you get the same style out of the box without any setup.
+
+A project-local oxfmt config takes precedence: if the directory being formatted contains its own `.oxfmtrc.*` (`.json`, `.jsonc`, `.ts`, `.js`, …), the bundled default is skipped and oxfmt uses yours. Override the bundled path explicitly with the `GO_FMT_OXFMTRC` environment variable, matching the other `GO_FMT_*` knobs.
+
 ## What it formats
 
 The built-in spacing rule, in summary:

--- a/cmd/fmt-ts-files.sh
+++ b/cmd/fmt-ts-files.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 support_dir="${GO_FMT_SUPPORT_DIR:-/opt/go-fmt/support}"
 tsx_bin="${TSX_BIN:-${support_dir}/node_modules/.bin/tsx}"
 oxfmt_bin="${OXFMT_BIN:-${support_dir}/node_modules/.bin/oxfmt}"
+oxfmtrc="${GO_FMT_OXFMTRC:-${support_dir}/.oxfmtrc.json}"
 blank_lines_script="${GO_FMT_BLANK_LINES_SCRIPT:-${support_dir}/blank-lines.ts}"
 validate_syntax_script="${GO_FMT_VALIDATE_SYNTAX_SCRIPT:-${support_dir}/validate-syntax.ts}"
 
@@ -58,9 +59,22 @@ else
 	"$tsx_bin" "$blank_lines_script"
 fi
 
+# Fall back to the bundled config only when the project has no oxfmt config of
+# its own; a project-local config (.oxfmtrc.json, .ts, .js, …) takes precedence
+# via oxfmt's native auto-discovery.
+detect_dir="${GO_FMT_SOURCES_CWD:-$PWD}"
+declare -a oxfmt_config_args=()
+shopt -s nullglob
+project_configs=("$detect_dir"/.oxfmtrc.*)
+shopt -u nullglob
+
+if [[ ${#project_configs[@]} -eq 0 && -f "$oxfmtrc" ]]; then
+	oxfmt_config_args=(--config "$oxfmtrc")
+fi
+
 if [[ ${#format_files[@]} -gt 0 ]]; then
 	printf '%s\0' "${format_files[@]}" \
-		| xargs -0 "$oxfmt_bin" --write --no-error-on-unmatched-pattern
+		| xargs -0 "$oxfmt_bin" "${oxfmt_config_args[@]}" --write --no-error-on-unmatched-pattern
 fi
 
 if [[ ${#syntax_files[@]} -gt 0 ]]; then

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -58,6 +58,7 @@ COPY --from=builder /out/goimports /usr/local/bin/goimports
 WORKDIR /opt/go-fmt/support
 COPY packages/devx/scripts/*.ts /opt/go-fmt/support/
 COPY packages/devx/scripts/package.json /opt/go-fmt/support/package.json
+COPY .oxfmtrc.json /opt/go-fmt/support/.oxfmtrc.json
 COPY cmd/fmt-ts /usr/local/bin/fmt-ts
 COPY cmd/fmt-ts-files.sh /usr/local/bin/fmt-ts-files.sh
 COPY cmd/fmt-all /usr/local/bin/fmt-all

--- a/docker/Dockerfile.node-ts
+++ b/docker/Dockerfile.node-ts
@@ -23,6 +23,7 @@ RUN node -e 'const p = require("./package.json"); const deps = ["oxc-parser", "o
 
 COPY packages/devx/scripts/*.ts /opt/go-fmt/support/
 COPY packages/devx/scripts/package.json /opt/go-fmt/support/package.json
+COPY .oxfmtrc.json /opt/go-fmt/support/.oxfmtrc.json
 COPY --from=source-builder /out/fmt-sources /usr/local/bin/fmt-sources
 COPY cmd/fmt-ts /usr/local/bin/fmt-ts
 COPY cmd/fmt-ts-files.sh /usr/local/bin/fmt-ts-files.sh


### PR DESCRIPTION
## What

The TS/Vue half of the pipeline runs `oxfmt` over sources but invokes it **without** `-c/--config`, relying on oxfmt auto-discovering `.oxfmtrc.json` from the current working directory. The repo-root [`.oxfmtrc.json`](.oxfmtrc.json) was **never copied into the published images** (`Dockerfile.node-ts`, `Dockerfile.full`), and the npm workspaces are `private`. So the project's intended TS/Vue style (`printWidth: 200`, tabs, single quotes, trailing commas) only took effect during local dev inside this repo, and was silently lost when the tool formatted a user's project — oxfmt fell back to its built-in defaults.

## Changes

- **`docker/Dockerfile.node-ts` / `docker/Dockerfile.full`** — bundle `.oxfmtrc.json` into both images at `/opt/go-fmt/support/.oxfmtrc.json`.
- **`cmd/fmt-ts-files.sh`** — add a `GO_FMT_OXFMTRC`-defaulted path (matching the existing `GO_FMT_*` env-var pattern) and pass `--config` to oxfmt **as a fallback**, skipped when the project being formatted has its own `.oxfmtrc.*` so a user's per-project config still wins via oxfmt's native auto-discovery.
- **`README.md`** — document the bundled default, the override semantics, and the `GO_FMT_OXFMTRC` knob.

## Precedence (default with user override)

If the project has no oxfmt config, the bundled default is applied. If it has its own `.oxfmtrc.*`, that wins. No regression to local `make format`: the repo root holds `.oxfmtrc.json`, so detection finds it, `--config` is skipped, and oxfmt resolves the root config natively as before.

## Verification

- `make format` from the repo root → `0 changed` (no regression).
- Throwaway git project with a mis-styled `.ts` file and **no** config → reformatted to the bundled style (tabs, single quotes, semicolons, trailing commas), confirming `--config /opt/go-fmt/support/.oxfmtrc.json` was applied.
- Same project with a project-local `.oxfmtrc.json` (`useTabs: false`, `singleQuote: false`, `semi: false`) → oxfmt honoured the project config (spaces, double quotes, no semicolons).

## Reviewer note

Source discovery uses `git ls-files`, so the bundled config only formats files in a git-tracked project (pre-existing behaviour, unrelated to this change).