### PR TITLE
fix: align node-ts release verification with bundled oxfmt single-quote style

### DIFF
--- a/scripts/release-image/assertions.sh
+++ b/scripts/release-image/assertions.sh
@@ -47,7 +47,9 @@ assert_file_contains() {
 	local file="$1"
 	local expected="$2"
 
-	if ! grep -Fq "$expected" "$file"; then
+	if [ ! -f "$file" ]; then
+		release_image_fail "file not found: ${file}"
+	elif ! grep -Fq "$expected" "$file"; then
 		release_image_fail "expected ${file} to contain: ${expected}"
 	fi
 }

--- a/scripts/release-image/assertions.sh
+++ b/scripts/release-image/assertions.sh
@@ -47,5 +47,7 @@ assert_file_contains() {
 	local file="$1"
 	local expected="$2"
 
-	grep -Fq "$expected" "$file"
+	if ! grep -Fq "$expected" "$file"; then
+		release_image_fail "expected ${file} to contain: ${expected}"
+	fi
 }

--- a/scripts/release-image/node-ts.sh
+++ b/scripts/release-image/node-ts.sh
@@ -10,7 +10,7 @@ verify_node_ts_image() {
 	write_node_ts_fixture "$tmpdir"
 
 	release_image_run_in_workdir "$tmpdir" "$image" .
-	assert_file_contains "${tmpdir}/sample.ts" 'const value = { name: "demo" };'
+	assert_file_contains "${tmpdir}/sample.ts" "const value = { name: 'demo' };"
 
 	if release_image_run --entrypoint sh "$image" -c 'command -v go' >/dev/null 2>&1; then
 		release_image_fail "node-ts image unexpectedly ships a Go toolchain: ${image}"


### PR DESCRIPTION
## Problem

The `Publish Release` job for **v0.3.0** failed at **Verify published release image** ([run 26706518226](https://github.com/oullin/go-fmt/actions/runs/26706518226/job/78708824786)).

PR #37 bundles `.oxfmtrc.json` (`"singleQuote": true`) into the images and applies it in userland, so the node-ts image now formats the fixture `const value={name:"demo"};` to **single quotes**:

```
const value = { name: 'demo' };
```

But `scripts/release-image/node-ts.sh` still asserted **double quotes**. Because `assert_file_contains` was a bare `grep -Fq`, the non-match exited `1` under `set -e` with no diagnostic — an opaque failure.

## Changes

- **node-ts.sh**: assert single quotes, matching the bundled config (also makes the check validate that PR #37's config is actually shipped and applied).
- **assertions.sh**: `assert_file_contains` now routes a miss through `release_image_fail` with a readable message instead of a silent `set -e` exit.

## Verification

- `make format` clean.
- Local repro: formatting the fixture with `oxfmt --config .oxfmtrc.json` produces `const value = { name: 'demo' };` and the updated assertion passes.

## Re-release

Do **not** re-dispatch v0.3.0 — that tag points at the broken commit and `verify-release-tag.sh` refuses to publish when HEAD ≠ tag SHA. Merging this `fix:` commit lets the Release Tag workflow cut **v0.3.1** and publish cleanly.