### PR TITLE
feat: add oxlint-based `lint` subcommand for unused-code detection

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "./node_modules/oxlint/configuration_schema.json",
+	"plugins": ["typescript"],
+	"categories": {
+		"correctness": "error"
+	},
+	"rules": {
+		"no-unused-vars": ["error", { "args": "after-used", "argsIgnorePattern": "^_", "varsIgnorePattern": "^_", "caughtErrors": "none" }],
+		"no-self-compare": "error",
+		"no-template-curly-in-string": "error",
+		"eqeqeq": ["error", "always"],
+		"no-var": "error",
+		"typescript/no-misused-new": "error",
+		"typescript/no-extra-non-null-assertion": "error",
+		"typescript/no-non-null-asserted-optional-chain": "error",
+		"typescript/no-duplicate-enum-values": "error",
+		"typescript/no-unsafe-declaration-merging": "error",
+		"typescript/prefer-as-const": "error",
+		"typescript/consistent-type-imports": "error"
+	}
+}

--- a/cmd/fmt-all
+++ b/cmd/fmt-all
@@ -2,11 +2,9 @@
 set -euo pipefail
 
 usage() {
-	printf 'usage: %s <format|format-all|lint|lint-all|go|ts|check|version|help> [args...]\n' "${0##*/}" >&2
-	printf '  format [paths...]                        run TS/Vue support, then Go formatting\n' >&2
+	printf 'usage: %s <format|format-all|go|ts|check|version|help> [args...]\n' "${0##*/}" >&2
+	printf '  format [paths...]                        run TS/Vue support + lint, then Go formatting\n' >&2
 	printf '  format-all                               run the full formatter pipeline against .\n' >&2
-	printf '  lint [paths...]                          run oxlint over TS/Vue files\n' >&2
-	printf '  lint-all                                 run oxlint over every TS/Vue file in .\n' >&2
 	printf '  go [check|format|version|help] [args...] run the Go formatter CLI\n' >&2
 	printf '  ts [paths...]                            run TS/Vue blank-line support and oxfmt\n' >&2
 	printf '  check|version|help [args...]             run the matching Go formatter CLI command\n' >&2
@@ -166,20 +164,9 @@ run_format_pipeline() {
 	section 'Formatting target(s)'
 	detail 'paths' "$*"
 	run_logged 'Running TS/Vue formatting' summarize_ts_format "$format_ts_bin" "$@"
+	run_logged 'Running TS/Vue lint' summarize_ts_lint "$lint_ts_bin" "$@"
 	run_logged 'Running Go formatting' summarize_go_format "$go_fmt_bin" format "$@"
 	section 'Formatting complete'
-	success_detail 'status' 'done'
-}
-
-run_lint_pipeline() {
-	if [[ $# -eq 0 ]]; then
-		set -- .
-	fi
-
-	section 'Linting target(s)'
-	detail 'paths' "$*"
-	run_logged 'Running TS/Vue lint' summarize_ts_lint "$lint_ts_bin" "$@"
-	section 'Linting complete'
 	success_detail 'status' 'done'
 }
 
@@ -194,17 +181,6 @@ case "$mode" in
 		fi
 
 		run_format_pipeline .
-		;;
-	lint)
-		run_lint_pipeline "$@"
-		;;
-	lint-all)
-		if [[ $# -ne 0 ]]; then
-			usage
-			exit 2
-		fi
-
-		run_lint_pipeline .
 		;;
 	go)
 		exec "$go_fmt_bin" "$@"

--- a/cmd/fmt-all
+++ b/cmd/fmt-all
@@ -2,9 +2,11 @@
 set -euo pipefail
 
 usage() {
-	printf 'usage: %s <format|format-all|go|ts|check|version|help> [args...]\n' "${0##*/}" >&2
+	printf 'usage: %s <format|format-all|lint|lint-all|go|ts|check|version|help> [args...]\n' "${0##*/}" >&2
 	printf '  format [paths...]                        run TS/Vue support, then Go formatting\n' >&2
 	printf '  format-all                               run the full formatter pipeline against .\n' >&2
+	printf '  lint [paths...]                          run oxlint over TS/Vue files\n' >&2
+	printf '  lint-all                                 run oxlint over every TS/Vue file in .\n' >&2
 	printf '  go [check|format|version|help] [args...] run the Go formatter CLI\n' >&2
 	printf '  ts [paths...]                            run TS/Vue blank-line support and oxfmt\n' >&2
 	printf '  check|version|help [args...]             run the matching Go formatter CLI command\n' >&2
@@ -20,6 +22,7 @@ shift
 
 go_fmt_bin="${GO_FMT_BIN:-/usr/local/bin/fmt-go}"
 format_ts_bin="${FORMAT_TS_BIN:-/usr/local/bin/fmt-ts}"
+lint_ts_bin="${FORMAT_LINT_BIN:-/usr/local/bin/fmt-lint}"
 
 bold=''
 dim=''
@@ -63,14 +66,16 @@ run_logged() {
 
 	section "$label"
 
-	if "$@" >"$log_file" 2>&1; then
+	local status=0
+	"$@" >"$log_file" 2>&1 || status="$?"
+
+	if [[ "$status" -eq 0 ]]; then
 		"$summary" "$log_file"
 		rm -f "$log_file"
 
 		return 0
 	fi
 
-	local status="$?"
 	failure "$label failed"
 	cat "$log_file" >&2
 	rm -f "$log_file"
@@ -136,6 +141,23 @@ summarize_go_format() {
 	fi
 }
 
+summarize_ts_lint() {
+	local log_file="$1"
+	local skipped_summary
+	local warnings_summary
+
+	skipped_summary="$(grep '^\[lint\] no TS/Vue files to lint\.' "$log_file" | tail -n 1 | sed 's/^\[lint\] //' || true)"
+	warnings_summary="$(grep -E 'Found [0-9]+ warning|[0-9]+ error' "$log_file" | tail -n 1 || true)"
+
+	if [[ -n "$skipped_summary" ]]; then
+		detail 'oxlint' "$skipped_summary"
+	elif [[ -n "$warnings_summary" ]]; then
+		detail 'oxlint' "$warnings_summary"
+	else
+		detail 'oxlint' 'no issues found'
+	fi
+}
+
 run_format_pipeline() {
 	if [[ $# -eq 0 ]]; then
 		set -- .
@@ -146,6 +168,18 @@ run_format_pipeline() {
 	run_logged 'Running TS/Vue formatting' summarize_ts_format "$format_ts_bin" "$@"
 	run_logged 'Running Go formatting' summarize_go_format "$go_fmt_bin" format "$@"
 	section 'Formatting complete'
+	success_detail 'status' 'done'
+}
+
+run_lint_pipeline() {
+	if [[ $# -eq 0 ]]; then
+		set -- .
+	fi
+
+	section 'Linting target(s)'
+	detail 'paths' "$*"
+	run_logged 'Running TS/Vue lint' summarize_ts_lint "$lint_ts_bin" "$@"
+	section 'Linting complete'
 	success_detail 'status' 'done'
 }
 
@@ -160,6 +194,17 @@ case "$mode" in
 		fi
 
 		run_format_pipeline .
+		;;
+	lint)
+		run_lint_pipeline "$@"
+		;;
+	lint-all)
+		if [[ $# -ne 0 ]]; then
+			usage
+			exit 2
+		fi
+
+		run_lint_pipeline .
 		;;
 	go)
 		exec "$go_fmt_bin" "$@"

--- a/cmd/fmt-lint
+++ b/cmd/fmt-lint
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fmt_ts_lint="${GO_FMT_TS_LINT_SH:-${script_dir}/fmt-ts-lint.sh}"
+
+declare -a args=("$@")
+
+if [[ ${#args[@]} -eq 0 ]]; then
+	args=(.)
+fi
+
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=safe.directory
+export GIT_CONFIG_VALUE_0="*"
+
+"$fmt_ts_lint" "${args[@]}"

--- a/cmd/fmt-ts-files.sh
+++ b/cmd/fmt-ts-files.sh
@@ -33,25 +33,32 @@ fi
 declare -a format_files=()
 declare -a syntax_files=()
 
+# Capture the source listings through temp files rather than process
+# substitution: a `while … done < <(cmd)` loop swallows cmd's exit status, so a
+# failing sources_cmd would silently yield an empty list and pass. Writing to a
+# file lets set -e catch the failure.
+tmp_format="$(mktemp)"
+tmp_syntax="$(mktemp)"
+trap 'rm -f "$tmp_format" "$tmp_syntax"' EXIT
+
+if [[ ${#sources_args[@]} -gt 0 ]]; then
+	"${sources_cmd[@]}" "${sources_args[@]}" "${args[@]}" > "$tmp_format"
+	"${sources_cmd[@]}" "${sources_args[@]}" --include-declarations "${args[@]}" > "$tmp_syntax"
+else
+	"${sources_cmd[@]}" "${args[@]}" > "$tmp_format"
+	"${sources_cmd[@]}" --include-declarations "${args[@]}" > "$tmp_syntax"
+fi
+
 while IFS= read -r -d '' file; do
 	format_files+=("$file")
-done < <(
-	if [[ ${#sources_args[@]} -gt 0 ]]; then
-		"${sources_cmd[@]}" "${sources_args[@]}" "${args[@]}"
-	else
-		"${sources_cmd[@]}" "${args[@]}"
-	fi
-)
+done < "$tmp_format"
 
 while IFS= read -r -d '' file; do
 	syntax_files+=("$file")
-done < <(
-	if [[ ${#sources_args[@]} -gt 0 ]]; then
-		"${sources_cmd[@]}" "${sources_args[@]}" --include-declarations "${args[@]}"
-	else
-		"${sources_cmd[@]}" --include-declarations "${args[@]}"
-	fi
-)
+done < "$tmp_syntax"
+
+rm -f "$tmp_format" "$tmp_syntax"
+trap - EXIT
 
 if [[ ${#format_files[@]} -gt 0 ]]; then
 	"$tsx_bin" "$blank_lines_script" "${format_files[@]}"
@@ -74,7 +81,7 @@ fi
 
 if [[ ${#format_files[@]} -gt 0 ]]; then
 	printf '%s\0' "${format_files[@]}" \
-		| xargs -0 "$oxfmt_bin" "${oxfmt_config_args[@]}" --write --no-error-on-unmatched-pattern
+		| xargs -0 "$oxfmt_bin" ${oxfmt_config_args[@]+"${oxfmt_config_args[@]}"} --write --no-error-on-unmatched-pattern
 fi
 
 if [[ ${#syntax_files[@]} -gt 0 ]]; then

--- a/cmd/fmt-ts-lint.sh
+++ b/cmd/fmt-ts-lint.sh
@@ -29,15 +29,25 @@ fi
 
 declare -a lint_files=()
 
+# Capture the source listing through a temp file rather than process
+# substitution: a `while … done < <(cmd)` loop swallows cmd's exit status, so a
+# failing sources_cmd would silently yield an empty list and pass. Writing to a
+# file lets set -e catch the failure.
+tmp_sources="$(mktemp)"
+trap 'rm -f "$tmp_sources"' EXIT
+
+if [[ ${#sources_args[@]} -gt 0 ]]; then
+	"${sources_cmd[@]}" "${sources_args[@]}" "${args[@]}" > "$tmp_sources"
+else
+	"${sources_cmd[@]}" "${args[@]}" > "$tmp_sources"
+fi
+
 while IFS= read -r -d '' file; do
 	lint_files+=("$file")
-done < <(
-	if [[ ${#sources_args[@]} -gt 0 ]]; then
-		"${sources_cmd[@]}" "${sources_args[@]}" "${args[@]}"
-	else
-		"${sources_cmd[@]}" "${args[@]}"
-	fi
-)
+done < "$tmp_sources"
+
+rm -f "$tmp_sources"
+trap - EXIT
 
 if [[ ${#lint_files[@]} -eq 0 ]]; then
 	echo "[lint] no TS/Vue files to lint."
@@ -49,8 +59,15 @@ fi
 # via oxlint's native auto-discovery.
 detect_dir="${GO_FMT_SOURCES_CWD:-$PWD}"
 declare -a oxlint_config_args=()
+# Match both the extensioned configs (.oxlintrc.json/.jsonc/…) and the
+# extensionless .oxlintrc. nullglob strips the glob when nothing matches, but
+# the literal .oxlintrc (no metacharacters) survives even when absent, so the
+# -f guard below filters to configs that actually exist on disk.
 shopt -s nullglob
-project_configs=("$detect_dir"/.oxlintrc.*)
+declare -a project_configs=()
+for candidate in "$detect_dir"/.oxlintrc "$detect_dir"/.oxlintrc.*; do
+	[[ -f "$candidate" ]] && project_configs+=("$candidate")
+done
 shopt -u nullglob
 
 if [[ ${#project_configs[@]} -eq 0 && -f "$oxlintrc" ]]; then

--- a/cmd/fmt-ts-lint.sh
+++ b/cmd/fmt-ts-lint.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+support_dir="${GO_FMT_SUPPORT_DIR:-/opt/go-fmt/support}"
+oxlint_bin="${OXLINT_BIN:-${support_dir}/node_modules/.bin/oxlint}"
+oxlintrc="${GO_FMT_OXLINTRC:-${support_dir}/.oxlintrc.json}"
+
+declare -a sources_cmd
+
+if [[ -n "${GO_FMT_SOURCES_BIN:-}" ]]; then
+	sources_cmd=("${GO_FMT_SOURCES_BIN}")
+elif [[ -x /usr/local/bin/fmt-sources ]]; then
+	sources_cmd=(/usr/local/bin/fmt-sources)
+else
+	sources_cmd=("${GO_BIN:-go}" -C "${GO_FMT_SOURCES_GO_WORKDIR:-packages/driver}" run "${GO_FMT_SOURCES_CMD:-./cmd/fmt-sources}")
+fi
+
+declare -a sources_args=()
+
+if [[ -n "${GO_FMT_SOURCES_CWD:-}" ]]; then
+	sources_args=(--cwd "${GO_FMT_SOURCES_CWD}")
+fi
+
+declare -a args=("$@")
+
+if [[ ${#args[@]} -eq 0 ]]; then
+	args=(.)
+fi
+
+declare -a lint_files=()
+
+while IFS= read -r -d '' file; do
+	lint_files+=("$file")
+done < <(
+	if [[ ${#sources_args[@]} -gt 0 ]]; then
+		"${sources_cmd[@]}" "${sources_args[@]}" "${args[@]}"
+	else
+		"${sources_cmd[@]}" "${args[@]}"
+	fi
+)
+
+if [[ ${#lint_files[@]} -eq 0 ]]; then
+	echo "[lint] no TS/Vue files to lint."
+	exit 0
+fi
+
+# Fall back to the bundled config only when the project has no oxlint config of
+# its own; a project-local config (.oxlintrc.json, .jsonc, …) takes precedence
+# via oxlint's native auto-discovery.
+detect_dir="${GO_FMT_SOURCES_CWD:-$PWD}"
+declare -a oxlint_config_args=()
+shopt -s nullglob
+project_configs=("$detect_dir"/.oxlintrc.*)
+shopt -u nullglob
+
+if [[ ${#project_configs[@]} -eq 0 && -f "$oxlintrc" ]]; then
+	oxlint_config_args=(--config "$oxlintrc")
+fi
+
+printf '%s\0' "${lint_files[@]}" \
+	| xargs -0 "$oxlint_bin" ${oxlint_config_args[@]+"${oxlint_config_args[@]}"}

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -37,7 +37,7 @@ RUN apk add --no-cache bash git
 
 WORKDIR /opt/go-fmt/support
 COPY packages/devx/package.json /opt/go-fmt/support/package.json
-RUN node -e 'const p = require("./package.json"); const deps = ["oxc-parser", "oxfmt", "tsx"]; console.log(deps.map((name) => `${name}@${p.devDependencies[name]}`).join(" "));' \
+RUN node -e 'const p = require("./package.json"); const deps = ["oxc-parser", "oxfmt", "oxlint", "tsx"]; console.log(deps.map((name) => `${name}@${p.devDependencies[name]}`).join(" "));' \
 	| xargs npm install --no-save
 
 FROM node-support
@@ -59,10 +59,13 @@ WORKDIR /opt/go-fmt/support
 COPY packages/devx/scripts/*.ts /opt/go-fmt/support/
 COPY packages/devx/scripts/package.json /opt/go-fmt/support/package.json
 COPY .oxfmtrc.json /opt/go-fmt/support/.oxfmtrc.json
+COPY .oxlintrc.json /opt/go-fmt/support/.oxlintrc.json
 COPY cmd/fmt-ts /usr/local/bin/fmt-ts
 COPY cmd/fmt-ts-files.sh /usr/local/bin/fmt-ts-files.sh
+COPY cmd/fmt-lint /usr/local/bin/fmt-lint
+COPY cmd/fmt-ts-lint.sh /usr/local/bin/fmt-ts-lint.sh
 COPY cmd/fmt-all /usr/local/bin/fmt-all
-RUN chmod +x /usr/local/bin/fmt-ts /usr/local/bin/fmt-ts-files.sh /usr/local/bin/fmt-all
+RUN chmod +x /usr/local/bin/fmt-ts /usr/local/bin/fmt-ts-files.sh /usr/local/bin/fmt-lint /usr/local/bin/fmt-ts-lint.sh /usr/local/bin/fmt-all
 
 WORKDIR /work
 

--- a/make/config.mk
+++ b/make/config.mk
@@ -13,7 +13,7 @@ RELEASE_PLATFORMS ?= darwin/amd64 darwin/arm64 linux/amd64 linux/arm64## Space-s
 FORMATTER_IMAGE ?= go-fmt-full:local## Local Docker image used by make format-all
 FORMATTER_DOCKERFILE ?= docker/Dockerfile.full## Dockerfile used for the local formatter image
 FORMATTER_BUILD ?= auto## Formatter image build policy: auto, always, or never
-FORMATTER_FINGERPRINT ?= $(shell { printf '%s\n' '$(FORMATTER_DOCKERFILE)' package.json pnpm-lock.yaml cmd/fmt-ts cmd/fmt-ts-files.sh cmd/fmt-all packages/devx/package.json packages/devx/scripts/package.json; find packages/devx/scripts -maxdepth 1 -type f -name '*.ts' -print; } | sort | while IFS= read -r f; do [ -f "$$f" ] && shasum -a 256 "$$f"; done | shasum -a 256 | awk '{print $$1}')## Fingerprint used to invalidate cached local formatter images
+FORMATTER_FINGERPRINT ?= $(shell { printf '%s\n' '$(FORMATTER_DOCKERFILE)' package.json pnpm-lock.yaml cmd/fmt-ts cmd/fmt-ts-files.sh cmd/fmt-lint cmd/fmt-ts-lint.sh cmd/fmt-all .oxlintrc.json packages/devx/package.json packages/devx/scripts/package.json; find packages/devx/scripts -maxdepth 1 -type f -name '*.ts' -print; } | sort | while IFS= read -r f; do [ -f "$$f" ] && shasum -a 256 "$$f"; done | shasum -a 256 | awk '{print $$1}')## Fingerprint used to invalidate cached local formatter images
 GO_IMAGE ?= go-fmt-go:local## Local Go-only Docker image
 NODE_TS_IMAGE ?= go-fmt-node-ts:local## Local Node/TS-only Docker image
 FULL_IMAGE ?= go-fmt-full:local## Local full Docker image

--- a/scripts/test-entrypoints.sh
+++ b/scripts/test-entrypoints.sh
@@ -5,3 +5,4 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 "${script_dir}/test-fmt-all-entrypoint.sh"
 "${script_dir}/test-fmt-ts-entrypoint.sh"
+"${script_dir}/test-fmt-lint-entrypoint.sh"

--- a/scripts/test-fmt-all-entrypoint.sh
+++ b/scripts/test-fmt-all-entrypoint.sh
@@ -27,6 +27,9 @@ printf '%s %s\n' "$name" "\$*" >> "$log_file"
 		printf '[blank-lines] processed 3 file(s) in /work, 0 changed\n'
 		printf 'Finished in 10ms on 3 files using 8 threads.\n'
 		;;
+		fmt-lint)
+		printf 'Found 0 warnings and 0 errors.\n'
+		;;
 		fmt-go)
 		if [[ "\${1:-}" == "format" ]]; then
 			printf '\nFormatter\n\n'
@@ -89,19 +92,23 @@ run_entrypoint() {
 
 	GO_FMT_BIN="$tmp_root/fmt-go-stub" \
 		FORMAT_TS_BIN="$tmp_root/fmt-ts-stub" \
+		FORMAT_LINT_BIN="$tmp_root/fmt-lint-stub" \
 		"$repo_root/cmd/fmt-all" "$@" >"$stdout_file" 2>"$stderr_file"
 }
 
 write_stub "$tmp_root/fmt-go-stub" fmt-go
 write_stub "$tmp_root/fmt-ts-stub" fmt-ts
+write_stub "$tmp_root/fmt-lint-stub" fmt-lint
 
 run_entrypoint format .
-assert_log_equals $'fmt-ts .\nfmt-go format .'
+assert_log_equals $'fmt-ts .\nfmt-lint .\nfmt-go format .'
 assert_contains "$stderr_file" '==> Formatting target(s)'
 assert_contains "$stderr_file" 'paths        .'
 assert_contains "$stderr_file" '==> Running TS/Vue formatting'
 assert_contains "$stderr_file" 'blank-lines  processed 3 file(s) in /work, 0 changed'
 assert_contains "$stderr_file" 'oxfmt        Finished in 10ms on 3 files using 8 threads.'
+assert_contains "$stderr_file" '==> Running TS/Vue lint'
+assert_contains "$stderr_file" 'oxlint       Found 0 warnings and 0 errors.'
 assert_contains "$stderr_file" '==> Running Go formatting'
 assert_contains "$stderr_file" 'go-fmt'
 assert_contains "$stderr_file" 'Formatted 2 file(s).'
@@ -114,7 +121,7 @@ assert_contains "$stderr_file" 'status'
 assert_contains "$stderr_file" 'done'
 
 run_entrypoint format-all
-assert_log_equals $'fmt-ts .\nfmt-go format .'
+assert_log_equals $'fmt-ts .\nfmt-lint .\nfmt-go format .'
 
 run_entrypoint go format .
 assert_log_equals 'fmt-go format .'
@@ -135,4 +142,4 @@ if run_entrypoint unknown; then
 	exit 1
 fi
 
-assert_contains "$stderr_file" 'usage: fmt-all <format|format-all|lint|lint-all|go|ts|check|version|help> [args...]'
+assert_contains "$stderr_file" 'usage: fmt-all <format|format-all|go|ts|check|version|help> [args...]'

--- a/scripts/test-fmt-all-entrypoint.sh
+++ b/scripts/test-fmt-all-entrypoint.sh
@@ -135,4 +135,4 @@ if run_entrypoint unknown; then
 	exit 1
 fi
 
-assert_contains "$stderr_file" 'usage: fmt-all <format|format-all|go|ts|check|version|help> [args...]'
+assert_contains "$stderr_file" 'usage: fmt-all <format|format-all|lint|lint-all|go|ts|check|version|help> [args...]'

--- a/scripts/test-fmt-lint-entrypoint.sh
+++ b/scripts/test-fmt-lint-entrypoint.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tmp_root="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$tmp_root"
+}
+
+trap cleanup EXIT
+
+support_dir="$tmp_root/support"
+bin_dir="$tmp_root/bin"
+workdir="$tmp_root/work"
+log_file="$tmp_root/invocations.log"
+
+mkdir -p "$support_dir/node_modules/.bin" "$bin_dir" "$workdir"
+: >"$log_file"
+
+write_executable() {
+	local path="$1"
+	local body="$2"
+
+	printf '%s\n' "$body" >"$path"
+	chmod +x "$path"
+}
+
+write_executable "$bin_dir/fmt-sources" '#!/usr/bin/env bash
+set -euo pipefail
+printf "fmt-sources %s\n" "$*" >> "'"$log_file"'"
+printf "fmt-sources-config %s %s %s\n" "${GIT_CONFIG_COUNT:-}" "${GIT_CONFIG_KEY_0:-}" "${GIT_CONFIG_VALUE_0:-}" >> "'"$log_file"'"
+printf "sample.ts\0"'
+
+write_executable "$support_dir/node_modules/.bin/oxlint" '#!/usr/bin/env bash
+set -euo pipefail
+printf "oxlint %s\n" "$*" >> "'"$log_file"'"'
+
+# Bundled config exists but no project-local config -> --config fallback is used.
+touch "$support_dir/.oxlintrc.json"
+
+(
+	cd "$workdir"
+	PATH="$bin_dir:$PATH" \
+		GO_FMT_SUPPORT_DIR="$support_dir" \
+		GO_FMT_SOURCES_BIN="$bin_dir/fmt-sources" \
+		"$repo_root/cmd/fmt-lint" .
+)
+
+expected=$'fmt-sources .\nfmt-sources-config 1 safe.directory *\noxlint --config '"$support_dir"$'/.oxlintrc.json sample.ts'
+actual="$(<"$log_file")"
+
+if [[ "$actual" != "$expected" ]]; then
+	printf 'unexpected invocation log\nexpected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+	exit 1
+fi
+
+# A project-local config takes precedence: no --config flag is passed.
+: >"$log_file"
+touch "$workdir/.oxlintrc.json"
+
+(
+	cd "$workdir"
+	PATH="$bin_dir:$PATH" \
+		GO_FMT_SUPPORT_DIR="$support_dir" \
+		GO_FMT_SOURCES_BIN="$bin_dir/fmt-sources" \
+		"$repo_root/cmd/fmt-lint" .
+)
+
+expected=$'fmt-sources .\nfmt-sources-config 1 safe.directory *\noxlint sample.ts'
+actual="$(<"$log_file")"
+
+if [[ "$actual" != "$expected" ]]; then
+	printf 'unexpected invocation log (project-local config)\nexpected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a **`lint` / `lint-all`** capability to the formatter image, so consumers (e.g. the sasu monorepo) can detect unused/dead code through the **same Docker image** they already use for formatting. It mirrors the existing `oxfmt` path entirely at the shell level — **no Go changes**. `oxlint@1.66.0` was already a `devx` devDependency; this installs it into the image and exposes it through the entrypoint.

## What's added

- **`cmd/fmt-ts-lint.sh`** — discovers TS/Vue files via `fmt-sources` (same scope as formatting) and runs `oxlint`. Project-local `.oxlintrc.*` takes precedence (oxlint auto-discovery); otherwise the bundled config is used.
- **`cmd/fmt-lint`** — wrapper mirroring `cmd/fmt-ts` (sets `git safe.directory`).
- **`cmd/fmt-all`** — new `lint` / `lint-all` subcommands with the same colored section/summary reporting as the format pipeline.
- **`.oxlintrc.json`** — bundled default config (severity = **error**), focused on:
  - **unused / dead code** (`no-unused-vars` with `^_` ignore, plus the `correctness` category which covers `no-unused-private-class-members`, `no-unused-labels`, `no-useless-*`, etc.)
  - **high-signal extras**: `no-self-compare`, `no-template-curly-in-string`, `eqeqeq`, `no-var`
  - **TypeScript hygiene**: `no-misused-new`, `no-extra-non-null-assertion`, `no-non-null-asserted-optional-chain`, `no-duplicate-enum-values`, `no-unsafe-declaration-merging`, `prefer-as-const`, `consistent-type-imports`
- **`docker/Dockerfile.full`** — installs `oxlint`; copies the bundled config + lint scripts.
- **`make/config.mk`** — includes the new files in `FORMATTER_FINGERPRINT` so the local image cache invalidates.

## Bug fix (incidental but important)

`run_logged` swallowed failures: `local status="$?"` after `if cmd; then …; fi` always read `0` (the `if` compound's status when the condition is false and there's no `else`), so a failing step was reported as `status done`. Reworked to `cmd || status=$?`. Without this, `lint` would never fail CI — and formatting failures were silently passing too.

## Notes / decisions

- **`require-await` was intentionally left out** of the bundled default. It conflicts with the legitimate, common pattern of marking a function `async` purely to satisfy a `Promise<void>` callback/interface contract (this repo's own `withFixture` test callbacks are an example). For a *shared* default that ships to many repos, that friction isn't worth it; projects can opt in via their own `.oxlintrc.json`.
- **Vue:** oxlint lints `.vue` `<script>` blocks (correctness, `eqeqeq`, `no-var`, `typescript/*` all apply), but **suppresses `no-unused-vars` for `.vue`** to avoid template-only-binding false positives. Net: zero false positives; unused-var detection is full for `.ts`/`.tsx`, limited for `.vue`. No `.vue` override needed.
- **Type-aware rules** (`no-floating-promises`, etc.) are out of scope — they require oxlint's experimental `--type-aware` mode (`tsc` type info, much slower). Type checks stay with `tsc`.

## Verification

- `bash scripts/test-entrypoints.sh` — new `test-fmt-lint-entrypoint.sh` covers config precedence (bundled vs project-local) and the git-env wiring; fmt-all usage assertion updated.
- Built `docker/Dockerfile.full` and ran through the image:
  - `lint .` on a clean tree → **exit 0**, `Linting complete`.
  - `lint .` with a planted unused `const` → **exit 123**, `Running TS/Vue lint failed` + diagnostic.
- `make format-all` clean (0 changed).

## Follow-up

A new image tag from this merge will be consumed in the sasu repo (image bump + a `make lint` target).