### PR TITLE
chore: shrink Docker images and add maintenance tooling

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -1,7 +1,7 @@
 name: Cleanup Old Container Images
 
 # Prunes stale go-fmt container versions from GHCR so old release tags do not
-# accumulate forever. Protects every `latest*` tag and the 10 most recent
+# accumulate forever. Protects every `latest*` tag and the 2 most recent
 # versions; only deletes versions older than the cut-off beyond those.
 #
 # Requires a PAT secret `GHCR_CLEANUP_TOKEN` with `packages:delete` scope:
@@ -39,5 +39,5 @@ jobs:
                   image-tags: '!latest*' # never delete latest, latest-go, latest-node-ts, latest-full
                   tag-selection: both
                   cut-off: 12w
-                  keep-n-most-recent: 10
+                  keep-n-most-recent: 2
                   dry-run: ${{ github.event_name == 'schedule' && 'false' || inputs.dry-run }}

--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -1,0 +1,43 @@
+name: Cleanup Old Container Images
+
+# Prunes stale go-fmt container versions from GHCR so old release tags do not
+# accumulate forever. Protects every `latest*` tag and the 10 most recent
+# versions; only deletes versions older than the cut-off beyond those.
+#
+# Requires a PAT secret `GHCR_CLEANUP_TOKEN` with `packages:delete` scope:
+# the default GITHUB_TOKEN cannot use tag-filter operators (e.g. `!latest*`).
+# Scheduled runs delete for real; manual runs default to a dry-run preview.
+
+on:
+    schedule:
+        - cron: '0 4 * * 1' # Mondays 04:00 UTC
+    workflow_dispatch:
+        inputs:
+            dry-run:
+                description: Only list what would be deleted, without deleting
+                type: boolean
+                default: true
+
+permissions:
+    packages: write
+
+concurrency:
+    group: cleanup-images
+    cancel-in-progress: false
+
+jobs:
+    cleanup:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Prune old go-fmt image versions
+              uses: snok/container-retention-policy@v3.1.0
+              with:
+                  account: oullin # change to "user" if oullin is a personal account
+                  token: ${{ secrets.GHCR_CLEANUP_TOKEN }}
+                  image-names: go-fmt
+                  image-tags: '!latest*' # never delete latest, latest-go, latest-node-ts, latest-full
+                  tag-selection: both
+                  cut-off: 12w
+                  keep-n-most-recent: 10
+                  dry-run: ${{ github.event_name == 'schedule' && 'false' || inputs.dry-run }}

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ include make/build-release.mk
 include make/test.mk
 include make/clean.mk
 
-.PHONY: help format format-all format-run image-go image-node-ts image-full build release test test-race test-short vet gofmt install clean host-format host-format-go host-format-ts host-format-full host-check host-version host-help
+.PHONY: help format format-all format-run image-go image-node-ts image-full docker-clean build release test test-race test-short vet gofmt install clean host-format host-format-go host-format-ts host-format-full host-check host-version host-help

--- a/README.md
+++ b/README.md
@@ -191,6 +191,33 @@ Published to `ghcr.io/oullin/go-fmt` for `linux/amd64` and `linux/arm64`.
 | `latest-go`, `<tag>-go`           | Go formatter CLI only.              | `fmt-go`   |
 | `latest-node-ts`, `<tag>-node-ts` | TS/Vue formatter only.              | `fmt-ts`   |
 
+The Go-containing images bundle a trimmed Go SDK (Go's own test suite, API data,
+std-library test fixtures, and unused tool binaries are stripped) because both
+`goimports` and `go vet` invoke the `go` toolchain at runtime. If the toolchain
+is ever absent, `go vet` is skipped gracefully rather than failing.
+
+### Docker maintenance
+
+Reclaim space taken by go-fmt's own Docker artifacts (local `*:local` images,
+fingerprinted build images, and the `go-fmt-cache` volume) without touching
+unrelated Docker state:
+
+```bash
+make docker-clean
+```
+
+The global Docker **build cache** is shared across all projects and cannot be
+pruned per project. Cap it so it can't grow unbounded by adding this to
+`~/.docker/daemon.json` and restarting Docker:
+
+```json
+{ "builder": { "gc": { "enabled": true, "defaultKeepStorage": "20GB" } } }
+```
+
+go-fmt's own run scripts already use `docker run --rm`, so normal usage leaves no
+stopped containers behind. Old `ghcr.io/oullin/go-fmt` tags on the registry are
+pruned automatically by the `Cleanup Old Container Images` workflow.
+
 ## Exit codes
 
 | Command  | Code | Meaning                              |

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -31,6 +31,17 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
 
 FROM golang:1.26-alpine AS gosdk
 
+# The runtime needs `go` for goimports (resolves imports via `go env`/std-lib scan)
+# and `go vet` (compiles packages for analysis). Strip the parts neither uses at
+# runtime: Go's own test suite, API compatibility data, docs, and the std-library
+# test fixtures (`testdata` dirs and `*_test.go`, which are never compiled when
+# building or vetting userland packages).
+RUN cd /usr/local/go && \
+	rm -rf test api doc misc && \
+	find src -type d -name testdata -prune -exec rm -rf {} + && \
+	find src -type f -name '*_test.go' -delete && \
+	rm -f pkg/tool/*/fix pkg/tool/*/cover pkg/tool/*/preprofile
+
 FROM node:25.8.2-alpine AS node-support
 
 RUN apk add --no-cache bash git

--- a/docker/Dockerfile.go
+++ b/docker/Dockerfile.go
@@ -31,6 +31,15 @@ FROM golang:1.26-alpine
 
 RUN apk add --no-cache bash git
 
+# Strip Go SDK parts neither `goimports` nor `go vet` uses at runtime: Go's own
+# test suite, API compatibility data, docs, std-library test fixtures, and tool
+# binaries only used by `go fix`/`go test -cover`/PGO.
+RUN cd /usr/local/go && \
+	rm -rf test api doc misc && \
+	find src -type d -name testdata -prune -exec rm -rf {} + && \
+	find src -type f -name '*_test.go' -delete && \
+	rm -f pkg/tool/*/fix pkg/tool/*/cover pkg/tool/*/preprofile
+
 WORKDIR /work
 
 ENV GOCACHE="/work/storage/.cache/go-build" \

--- a/make/images.mk
+++ b/make/images.mk
@@ -9,13 +9,16 @@ image-full: ## Build the local full Go + TS formatter image
 
 docker-clean: ## Remove go-fmt's local images, fingerprinted images, and cache volume
 	@# Stop and remove containers created from go-fmt local images.
-	-@docker ps -aq --filter ancestor='$(strip $(GO_IMAGE))' \
+	@# Guard with a non-empty check instead of `xargs -r` (a GNU extension absent on BSD/macOS).
+	-@containers=$$(docker ps -aq --filter ancestor='$(strip $(GO_IMAGE))' \
 		--filter ancestor='$(strip $(NODE_TS_IMAGE))' \
-		--filter ancestor='$(strip $(FULL_IMAGE))' | xargs -r docker rm -f
+		--filter ancestor='$(strip $(FULL_IMAGE))'); \
+		if [ -n "$$containers" ]; then echo "$$containers" | xargs docker rm -f; fi
 	@# Remove the local build images.
 	-@docker rmi -f '$(strip $(GO_IMAGE))' '$(strip $(NODE_TS_IMAGE))' '$(strip $(FULL_IMAGE))' 2>/dev/null
 	@# Remove any image carrying the project fingerprint label (stale cached builds).
-	-@docker images -q --filter label=local.go-fmt.formatter-fingerprint | sort -u | xargs -r docker rmi -f
+	-@images=$$(docker images -q --filter label=local.go-fmt.formatter-fingerprint | sort -u); \
+		if [ -n "$$images" ]; then echo "$$images" | xargs docker rmi -f; fi
 	@# Remove the shared cache volume.
 	-@docker volume rm '$(strip $(GO_FMT_CACHE_VOLUME))' 2>/dev/null
 	@# Drop dangling images left behind by go-fmt rebuilds.

--- a/make/images.mk
+++ b/make/images.mk
@@ -6,3 +6,19 @@ image-node-ts: ## Build the local Node/TS-only formatter image
 
 image-full: ## Build the local full Go + TS formatter image
 	@docker build --build-arg VERSION='$(strip $(VERSION))' --label 'local.go-fmt.formatter-fingerprint=$(strip $(FORMATTER_FINGERPRINT))' -f docker/Dockerfile.full -t '$(strip $(FULL_IMAGE))' .
+
+docker-clean: ## Remove go-fmt's local images, fingerprinted images, and cache volume
+	@# Stop and remove containers created from go-fmt local images.
+	-@docker ps -aq --filter ancestor='$(strip $(GO_IMAGE))' \
+		--filter ancestor='$(strip $(NODE_TS_IMAGE))' \
+		--filter ancestor='$(strip $(FULL_IMAGE))' | xargs -r docker rm -f
+	@# Remove the local build images.
+	-@docker rmi -f '$(strip $(GO_IMAGE))' '$(strip $(NODE_TS_IMAGE))' '$(strip $(FULL_IMAGE))' 2>/dev/null
+	@# Remove any image carrying the project fingerprint label (stale cached builds).
+	-@docker images -q --filter label=local.go-fmt.formatter-fingerprint | sort -u | xargs -r docker rmi -f
+	@# Remove the shared cache volume.
+	-@docker volume rm '$(strip $(GO_FMT_CACHE_VOLUME))' 2>/dev/null
+	@# Drop dangling images left behind by go-fmt rebuilds.
+	-@docker image prune -f --filter label=local.go-fmt.formatter-fingerprint
+	@# Note: the global Docker build cache cannot be scoped per project; cap it via
+	@# ~/.docker/daemon.json (see README "Docker maintenance") rather than pruning it here.

--- a/packages/driver/report/render.go
+++ b/packages/driver/report/render.go
@@ -54,7 +54,7 @@ func combinedResult(report Combined) string {
 
 func vetStatus(report vet.Report) string {
 	switch {
-	case report.Root == "":
+	case report.Skipped || report.Root == "":
 		return "skipped"
 	case report.ErrorCount() > 0:
 		return "fail"

--- a/packages/driver/report/text.go
+++ b/packages/driver/report/text.go
@@ -135,7 +135,13 @@ func renderFormatterText(w io.Writer, cwd, mode string, report formatterengine.R
 func renderVetText(w io.Writer, cwd string, report Combined) error {
 	switch vetStatus(report.Vet) {
 	case "skipped":
-		if _, err := color.New(color.FgYellow).Fprintf(w, "  Skipped automatic go vet ./... because no Go module or workspace was detected.\n\n"); err != nil {
+		reason := "no Go module or workspace was detected"
+
+		if report.Vet.Skipped {
+			reason = "the Go toolchain is not available"
+		}
+
+		if _, err := color.New(color.FgYellow).Fprint(w, "  Skipped automatic go vet ./... because "+reason+".\n\n"); err != nil {
 			return err
 		}
 	case "pass":

--- a/packages/vet/vet.go
+++ b/packages/vet/vet.go
@@ -23,13 +23,18 @@ type ErrorResult struct {
 
 // Report summarizes the automatic go vet run.
 type Report struct {
-	Root   string        `json:"root,omitempty"`
-	Errors []ErrorResult `json:"errors,omitempty"`
+	Root    string        `json:"root,omitempty"`
+	Skipped bool          `json:"skipped,omitempty"`
+	Errors  []ErrorResult `json:"errors,omitempty"`
 }
 
 // Default returns the default vet configuration.
 func Default() Config {
 	return Config{Enabled: true}
+}
+
+var lookGoPath = func() (string, error) {
+	return exec.LookPath("go")
 }
 
 var goEnvOutput = func(workRoot string, keys ...string) ([]byte, error) {
@@ -51,6 +56,10 @@ var goListModulesOutput = func(root string) ([]byte, error) {
 func Run(workRoot string, cfg Config) Report {
 	if !cfg.Enabled {
 		return Report{}
+	}
+
+	if _, err := lookGoPath(); err != nil {
+		return Report{Skipped: true}
 	}
 
 	root, err := discoverVetRoot(workRoot)

--- a/packages/vet/vet.go
+++ b/packages/vet/vet.go
@@ -37,16 +37,27 @@ var lookGoPath = func() (string, error) {
 	return exec.LookPath("go")
 }
 
+// goBinary resolves the go executable via lookGoPath so the toolchain location is
+// sourced consistently (and honours the lookGoPath stub in tests), falling back to
+// the bare "go" name when resolution fails.
+func goBinary() string {
+	if path, err := lookGoPath(); err == nil {
+		return path
+	}
+
+	return "go"
+}
+
 var goEnvOutput = func(workRoot string, keys ...string) ([]byte, error) {
 	args := append([]string{"env"}, keys...)
-	cmd := exec.Command("go", args...)
+	cmd := exec.Command(goBinary(), args...)
 	cmd.Dir = workRoot
 
 	return cmd.Output()
 }
 
 var goListModulesOutput = func(root string) ([]byte, error) {
-	cmd := exec.Command("go", "list", "-f", "{{.Dir}}", "-m")
+	cmd := exec.Command(goBinary(), "list", "-f", "{{.Dir}}", "-m")
 	cmd.Dir = root
 
 	return cmd.Output()
@@ -217,7 +228,7 @@ func runGoVet(root string) *ErrorResult {
 		return nil
 	}
 
-	cmd := exec.Command("go", "vet", "./...")
+	cmd := exec.Command(goBinary(), "vet", "./...")
 	cmd.Dir = root
 
 	out, err := cmd.CombinedOutput()

--- a/packages/vet/vet_test.go
+++ b/packages/vet/vet_test.go
@@ -51,6 +51,24 @@ func TestRunSkipsWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestRunSkipsWhenGoToolchainUnavailable(t *testing.T) {
+	restore := stubLookGoPath(t, func() (string, error) {
+		return "", exec.ErrNotFound
+	})
+
+	defer restore()
+
+	report := Run(t.TempDir(), Default())
+
+	if !report.Skipped {
+		t.Fatalf("expected skipped report, got %#v", report)
+	}
+
+	if report.Root != "" || report.ErrorCount() != 0 {
+		t.Fatalf("expected empty skipped report, got %#v", report)
+	}
+}
+
 func TestRunPrefersWorkspace(t *testing.T) {
 	workRoot := t.TempDir()
 	workspaceRoot := t.TempDir()
@@ -238,6 +256,17 @@ func TestGoEnvWrapsGenericErrors(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "resolve go GOWORK GOMOD: boom") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func stubLookGoPath(t *testing.T, fn func() (string, error)) func() {
+	t.Helper()
+
+	previous := lookGoPath
+	lookGoPath = fn
+
+	return func() {
+		lookGoPath = previous
 	}
 }
 


### PR DESCRIPTION
## Context

Docker image footprint had grown: the full image was 815 MB (1.84 GB for some per-branch support builds) and old release tags accumulate on GHCR with no retention. This reduces image size, adds project-scoped local cleanup, and auto-prunes old registry tags.

## Changes

**Trim the bundled Go SDK** (`docker/Dockerfile.full`, `docker/Dockerfile.go`)
Both `goimports` (embedded `golang.org/x/tools/imports`) and `go vet` shell out to the `go` toolchain at runtime, so the SDK must stay — but Go's own test suite, API data, std-library test fixtures (`testdata` + `*_test.go`), and unused tool binaries (`fix`, `cover`, `preprofile`) can go.

| Image | Before | After |
|---|---|---|
| full | 815 MB | **698 MB** (−14%) |
| go | ~500 MB | **402 MB** |

Verified: goimports still adds missing imports and `go vet` passes on both; release-verify fixtures and a real `make format` run (55 Go files) pass.

**Graceful vet skip** (`packages/vet/vet.go`, `report/render.go`, `report/text.go`)
`go vet` now skips cleanly when the `go` toolchain is absent instead of erroring. New `Skipped` field + distinct report message; test added.

**`make docker-clean`** (`make/images.mk`, `Makefile`)
Removes only go-fmt's own local images, fingerprinted builds, and the `go-fmt-cache` volume — no system-wide prune.

**GHCR retention** (`.github/workflows/cleanup-images.yml`)
Weekly prune keeping all `latest*` tags + the 2 most recent versions; manual runs default to dry-run. Requires an org secret `GHCR_CLEANUP_TOKEN` (classic PAT, `delete:packages`).

**Docs** (`README.md`)
Docker maintenance section: `docker-clean`, build-cache cap via `daemon.json`.

## Test plan
- [x] `go test ./...` across vet/driver/formatter packages
- [x] Built both images, verified goimports + vet functionally
- [x] `make format` against the repo
- [ ] Dry-run the cleanup workflow once merged to `main`