### PR TITLE
fix: make release asset publishing idempotent on retry

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,6 +53,13 @@ release:
     # notes) before this runs; goreleaser only attaches the binary assets.
     mode: keep-existing
 
+    # Make re-running Publish Release for a tag idempotent. mode: keep-existing
+    # preserves the release but still re-uploads every asset, so a retry after a
+    # partial publish died with `422 already_exists` before reaching the cask.
+    # Replacing same-named assets lets the retry path in publish-release.yml
+    # actually work.
+    replace_existing_artifacts: true
+
 homebrew_casks:
     - name: fmtkit
       repository:


### PR DESCRIPTION
Follow-up to #48, from the `v0.5.0` release failing.

## What happened

`v0.5.0` tagged and published all four binaries, then **failed at the Homebrew cask push** on a bad `HOMEBREW_TAP_TOKEN` ([run](https://github.com/oullin/fmtkit/actions/runs/29475493508)):

```
homebrew cask: could not get default branch:
GET https://api.github.com/repos/oullin/homebrew-fmtkit: 401 Bad credentials
```

After the token was rotated, the retry via `Publish Release` **still failed** — this time on the assets the first run had already uploaded ([run](https://github.com/oullin/fmtkit/actions/runs/29476354302)):

```
upload failed: POST .../releases/354891533/assets?name=fmtkit_0.5.0_linux_arm64.tar.gz
422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists}]
⨯ release failed after 1m28s
```

## Why

`release.mode: keep-existing` preserves the *release*, but goreleaser still re-uploads every *asset*. So the documented retry path (`Publish Release` → `workflow_dispatch` with a `tag`) could not actually succeed against a tag whose assets were already published. Because the upload step aborts the run, it never reaches `homebrew_casks` — the exact step the retry existed to fix.

The tap currently has no `Casks/` directory at all; the cask has never been pushed.

## Fix

Set `release.replace_existing_artifacts: true` so a retry replaces same-named assets and proceeds to the cask.

## Scope / caveat

`verify-release-tag.sh` checks out the **tagged commit**, so goreleaser reads the config as it existed at that tag. This fix therefore applies to **releases tagged from this commit onward** — it does not retroactively make `v0.5.0` retryable. Unblocking `v0.5.0` needs its existing assets deleted once, then a rerun.

## Verification

- `goreleaser check` passes locally.
- CI `binary` job re-validates the config via `goreleaser-action` with `args: check`.