### PR TITLE
docs: resolve the latest tag in the release install snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ fmtkit format .
 The binary embeds the TS toolchain (oxfmt, oxlint, oxc-parser and the support scripts, compiled with Bun) and extracts it to your user cache directory on first run. Homebrew casks are macOS-only; on Linux, download the same binary from GitHub Releases instead:
 
 ```bash
-curl -fsSL https://github.com/oullin/fmtkit/releases/download/v0.5.0/fmtkit_0.5.0_linux_amd64.tar.gz | tar -xz fmtkit
+tag=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/oullin/fmtkit/releases/latest | sed 's#.*/##')
+curl -fsSL "https://github.com/oullin/fmtkit/releases/download/${tag}/fmtkit_${tag#v}_linux_amd64.tar.gz" | tar -xz fmtkit
 sudo install -m 0755 fmtkit /usr/local/bin/fmtkit
 ```
 
-Archives are published for `darwin`/`linux` × `amd64`/`arm64` with a `checksums.txt`; swap in the [latest release](https://github.com/oullin/fmtkit/releases/latest) tag and your platform.
+Archives are published for `darwin`/`linux` × `amd64`/`arm64` with a `checksums.txt`; swap `linux_amd64` for your platform. The snippet resolves the [latest release](https://github.com/oullin/fmtkit/releases/latest) rather than naming a version, so it does not go stale. For CI, pin `tag` to a known release instead.
 
 **With Go** (good for local hacking and contributors):
 


### PR DESCRIPTION
The Linux install example in the README pinned `v0.5.0`:

```bash
curl -fsSL https://github.com/oullin/fmtkit/releases/download/v0.5.0/fmtkit_0.5.0_linux_amd64.tar.gz | tar -xz fmtkit
```

That release was stranded (binaries published, cask push failed on a bad token) and has since been deleted in favour of `v0.5.1`, so the command now 404s.

## Why not just bump it to v0.5.1

Pinning a version in this file is self-defeating. `create-release-tag.sh` has no skip path and defaults to a patch bump, so **every merge to `main` cuts a release** — including the merge of this very PR. A README that names `v0.5.1` would be stale the moment it lands.

## Fix

Resolve the tag from the `releases/latest` redirect:

```bash
tag=$(curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/oullin/fmtkit/releases/latest | sed 's#.*/##')
curl -fsSL "https://github.com/oullin/fmtkit/releases/download/${tag}/fmtkit_${tag#v}_linux_amd64.tar.gz" | tar -xz fmtkit
sudo install -m 0755 fmtkit /usr/local/bin/fmtkit
```

CI still wants a deliberate pin, so the surrounding prose now says so explicitly rather than implying everyone should track latest.

## Verification

Ran the snippet against the live release: resolves `v0.5.1`, and the resulting asset URL returns `HTTP 200`.

Also audited the rest of the docs — no stale Docker/`--host-path` references remain, and the `brew tap oullin/fmtkit` + `brew install --cask fmtkit` instructions match the published cask.

Related: the tap README is now documented too — oullin/homebrew-fmtkit@1fb67d3.