### PR TITLE
fix: let the project passes own the style, not oxfmt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -178,6 +178,11 @@ jobs:
             - name: Smoke test the self-contained binary
               run: ./infra/scripts/tasks/test-binary-smoke.sh
 
+            # Runs here rather than in `check`, which has no Go: the only tool
+            # that can say whether this tree is formatted is fmtkit itself.
+            - name: Check the repository is fmtkit-formatted
+              run: ./infra/scripts/tasks/check-self-formatted.sh
+
     coverage:
         needs: test
         runs-on: ubuntu-latest

--- a/infra/scripts/release/oxfmt-inprocess/cli-patcher.ts
+++ b/infra/scripts/release/oxfmt-inprocess/cli-patcher.ts
@@ -100,7 +100,9 @@ export class OxfmtCliPatcher {
 			return written;
 		}
 
-		return ok({ cliPath, apiModuleSpecifier: bindings.value.moduleSpecifier });
+		return ok(
+			{ cliPath, apiModuleSpecifier: bindings.value.moduleSpecifier },
+		);
 	}
 
 	/**

--- a/infra/scripts/release/oxfmt-inprocess/text-files.ts
+++ b/infra/scripts/release/oxfmt-inprocess/text-files.ts
@@ -38,7 +38,9 @@ export class NodeTextFiles implements TextFiles {
 	 */
 	readText(path: string): Result<string, OxfmtFileUnreadable> {
 		try {
-			return ok(readFileSync(path, 'utf8'));
+			return ok(
+				readFileSync(path, 'utf8'),
+			);
 		} catch (cause) {
 			return err(new OxfmtFileUnreadable(path, cause));
 		}

--- a/infra/scripts/tasks/check-self-formatted.sh
+++ b/infra/scripts/tasks/check-self-formatted.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Asserts this repository is formatted the way fmtkit formats it — by running
+# fmtkit over it and failing if anything moved.
+#
+# This is the only honest way to check the tree. fmtkit's format is the
+# pipeline's output (blank-lines → oxfmt → fluent-chains), and the project
+# passes run *after* oxfmt and deliberately diverge from it: they expand calls
+# and chains that oxfmt, left to itself, would collapse back. So bare
+# `oxfmt --check` disagrees with correctly formatted source by design, and using
+# it here would be checking the tree against a tool that is not the formatter.
+#
+# The pipeline has no read-only mode for TS, so this formats and then diffs.
+# It is meant for CI and for a clean tree; it rewrites files in place.
+
+source "$(dirname "${BASH_SOURCE[0]}")/env.sh"
+
+cd "$REPO_ROOT"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+	printf 'check-self-formatted: the working tree is dirty; commit or stash first\n' >&2
+	git status --short >&2
+	exit 1
+fi
+
+"${REPO_ROOT}/infra/scripts/tasks/fmtkit.sh" format-all
+
+if git diff --quiet; then
+	printf 'repository is fmtkit-formatted\n'
+	exit 0
+fi
+
+printf '\ncheck-self-formatted: fmtkit reformatted the following; commit the result:\n' >&2
+git diff --name-only >&2
+printf '\n' >&2
+git --no-pager diff >&2
+
+exit 1

--- a/packages/devx/package.json
+++ b/packages/devx/package.json
@@ -37,14 +37,10 @@
 		"#devx/validate-syntax.js": "./scripts/validate-syntax.ts"
 	},
 	"scripts": {
-		"blank-lines": "cd ../.. && tsx packages/devx/scripts/blank-lines.ts",
-		"blank-lines:check": "cd ../.. && tsx packages/devx/scripts/blank-lines.ts --check",
 		"validate-syntax": "cd ../.. && tsx packages/devx/scripts/validate-syntax.ts",
 		"lint": "cd ../.. && git ls-files --cached --others --exclude-standard -z | xargs -0 packages/devx/node_modules/.bin/oxlint --fix",
 		"lint:check": "cd ../.. && git ls-files --cached --others --exclude-standard -z | xargs -0 packages/devx/node_modules/.bin/oxlint",
-		"oxfmt": "cd ../.. && git ls-files --cached --others --exclude-standard -z | xargs -0 packages/devx/node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern",
-		"oxfmt:check": "cd ../.. && git ls-files --cached --others --exclude-standard -z | xargs -0 packages/devx/node_modules/.bin/oxfmt --check --no-error-on-unmatched-pattern",
-		"check": "pnpm blank-lines:check && pnpm lint:check && pnpm oxfmt:check",
+		"check": "pnpm lint:check",
 		"test": "tsx --test scripts/*.test.ts scripts/__tests__/*.test.ts",
 		"test:coverage": "node --import tsx --test --experimental-test-coverage --test-coverage-lines=90 scripts/*.test.ts scripts/__tests__/*.test.ts",
 		"typecheck": "tsc --noEmit"

--- a/packages/devx/scripts/__tests__/alias-specifiers.test.ts
+++ b/packages/devx/scripts/__tests__/alias-specifiers.test.ts
@@ -15,13 +15,13 @@ type Node = {
 };
 
 const sourceExtensions = new Set(['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx']);
-
-// sidecar.ts is a bundler-only entry point that must reach the oxfmt/oxlint
-// CLI internals in node_modules; oxlint's exports map blocks the bare
-// specifier the alias map would need, so its relative imports are exempt.
 const exemptFiles = new Set(['sidecar.ts']);
 
-const scriptsDir = dirname(fileURLToPath(import.meta.resolve('#devx/ast')));
+const scriptsDir = dirname(
+	fileURLToPath(
+		import.meta.resolve('#devx/ast'),
+	),
+);
 
 function isRelativeSpecifier(value: string): boolean {
 	return value.startsWith('./') || value.startsWith('../');
@@ -74,7 +74,10 @@ function isSourceFile(name: string): boolean {
 }
 
 async function listSourceFiles(dir: string): Promise<string[]> {
-	const entries = await readdir(dir, { recursive: true, withFileTypes: true });
+	const entries = await readdir(
+		dir,
+		{ recursive: true, withFileTypes: true },
+	);
 
 	const files: string[] = [];
 

--- a/packages/devx/scripts/__tests__/files.test.ts
+++ b/packages/devx/scripts/__tests__/files.test.ts
@@ -6,12 +6,20 @@ import { test } from 'node:test';
 import { dirExists, listSourceFiles, processFile } from '#devx/files';
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
-	const dir = await mkdtemp(join(tmpdir(), 'fmtkit-devx-files-'));
+	const dir = await mkdtemp(
+		join(
+			tmpdir(),
+			'fmtkit-devx-files-',
+		),
+	);
 
 	try {
 		await fn(dir);
 	} finally {
-		await rm(dir, { recursive: true, force: true });
+		await rm(
+			dir,
+			{ recursive: true, force: true },
+		);
 	}
 }
 
@@ -25,11 +33,20 @@ test('dirExists reports existing directories and missing paths', async () => {
 
 test('listSourceFiles returns TypeScript and Vue files only', async () => {
 	await withTempDir(async (dir) => {
-		await writeFile(join(dir, 'component.vue'), '<script setup lang="ts">\nconst value = 1;\n</script>\n');
+		await writeFile(
+			join(dir, 'component.vue'),
+			'<script setup lang="ts">\nconst value = 1;\n</script>\n',
+		);
 
-		await writeFile(join(dir, 'source.ts'), 'const value = 1;\n');
+		await writeFile(
+			join(dir, 'source.ts'),
+			'const value = 1;\n',
+		);
 
-		await writeFile(join(dir, 'notes.md'), '# Notes\n');
+		await writeFile(
+			join(dir, 'notes.md'),
+			'# Notes\n',
+		);
 
 		const files = (await listSourceFiles(dir)).map((file) => {
 			return file.slice(dir.length + 1);
@@ -74,7 +91,10 @@ test('processFile rewrites Vue script blocks and reports unchanged files', async
 	await withTempDir(async (dir) => {
 		const file = join(dir, 'component.vue');
 
-		await writeFile(file, ['<script setup lang="ts">', 'const value = 1;', 'if (value) console.log(value);', '</script>', ''].join('\n'));
+		await writeFile(
+			file,
+			['<script setup lang="ts">', 'const value = 1;', 'if (value) console.log(value);', '</script>', ''].join('\n'),
+		);
 
 		assert.equal(await processFile(file, false), true);
 

--- a/packages/devx/scripts/blank-lines.test.ts
+++ b/packages/devx/scripts/blank-lines.test.ts
@@ -6,208 +6,235 @@ import { join } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-const script = fileURLToPath(import.meta.resolve('#devx/blank-lines'));
-const tsx = fileURLToPath(import.meta.resolve('tsx/cli'));
+const script = fileURLToPath(
+	import.meta.resolve('#devx/blank-lines'),
+);
+const tsx = fileURLToPath(
+	import.meta.resolve('tsx/cli'),
+);
 
 function run(command: string, args: string[], cwd: string): void {
-	const result = spawnSync(command, args, { cwd, encoding: 'utf8' });
+	const result = spawnSync(
+		command,
+		args,
+		{ cwd, encoding: 'utf8' },
+	);
 
 	assert.equal(result.status, 0, result.stderr || result.stdout);
 }
 
 async function withFixture(files: Record<string, string>, fn: (dir: string) => Promise<void>): Promise<void> {
-	const dir = await mkdtemp(join(tmpdir(), 'fmtkit-blank-lines-'));
+	const dir = await mkdtemp(
+		join(
+			tmpdir(),
+			'fmtkit-blank-lines-',
+		),
+	);
 
 	try {
-		run('git', ['init', '-q'], dir);
+		run(
+			'git',
+			['init', '-q'],
+			dir,
+		);
 
 		for (const [file, content] of Object.entries(files)) {
-			await writeFile(join(dir, file), content);
+			await writeFile(
+				join(dir, file),
+				content,
+			);
 		}
 
-		run('git', ['add', '.'], dir);
+		run(
+			'git',
+			['add', '.'],
+			dir,
+		);
 
 		await fn(dir);
 	} finally {
-		await rm(dir, { recursive: true, force: true });
+		await rm(
+			dir,
+			{ recursive: true, force: true },
+		);
 	}
 }
 
 test('adds expected blank lines in Vue script blocks', async () => {
 	await withFixture(
 		{
-			'AgentDock.vue': [
-				'<script setup lang="ts">',
-				'const hoveredItem = computed(() => {',
-				'    const id = hoveredId.value;',
-				'    if (!id) return null;',
-				'    if (id in systemLabels) return { id, label: systemLabels[id], shortcut: undefined };',
-				'    return props.items.find((i) => i.id === id) ?? null;',
-				'});',
-				'</script>',
-				'',
-			].join('\n'),
-		},
+				'AgentDock.vue': [
+					'<script setup lang="ts">',
+					'const hoveredItem = computed(() => {',
+					'    const id = hoveredId.value;',
+					'    if (!id) return null;',
+					'    if (id in systemLabels) return { id, label: systemLabels[id], shortcut: undefined };',
+					'    return props.items.find((i) => i.id === id) ?? null;',
+					'});',
+					'</script>',
+					'',
+				].join('\n'),
+			},
 		async (dir) => {
-			run(process.execPath, [tsx, script, 'AgentDock.vue'], dir);
+				run(process.execPath, [tsx, script, 'AgentDock.vue'], dir);
 
-			const output = await readFile(join(dir, 'AgentDock.vue'), 'utf8');
+				const output = await readFile(join(dir, 'AgentDock.vue'), 'utf8');
 
-			assert.match(output, /const hoveredItem = computed\(\(\) => \{\n    const id = hoveredId\.value;\n\n    if \(!id\) \{/);
-			assert.match(output, /return null;\n    \}\n\n    if \(id in systemLabels\) \{/);
-			assert.match(output, /shortcut: undefined \};\n    \}\n\n    return props\.items/);
-		},
+				assert.match(output, /const hoveredItem = computed\(\(\) => \{\n    const id = hoveredId\.value;\n\n    if \(!id\) \{/);
+				assert.match(output, /return null;\n    \}\n\n    if \(id in systemLabels\) \{/);
+				assert.match(output, /shortcut: undefined \};\n    \}\n\n    return props\.items/);
+			},
 	);
 });
 
 test('keeps adjacent computed declarations syntactically valid', async () => {
 	await withFixture(
 		{
-			'useAppController.ts': [
-				'import { computed, ref } from "vue";',
-				'',
-				'export function useAppController() {',
-				'\tconst searchQuery = ref("");',
-				'\tconst debouncedSearch = ref("");',
-				'\tconst normalizedSearch = computed(() => searchQuery.value.trim().toLowerCase());',
-				'\tconst normalizedDebouncedSearch = computed(() => debouncedSearch.value.trim().toLowerCase());',
-				'',
-				'\treturn { normalizedSearch, normalizedDebouncedSearch };',
-				'}',
-				'',
-			].join('\n'),
-		},
+				'useAppController.ts': [
+					'import { computed, ref } from "vue";',
+					'',
+					'export function useAppController() {',
+					'\tconst searchQuery = ref("");',
+					'\tconst debouncedSearch = ref("");',
+					'\tconst normalizedSearch = computed(() => searchQuery.value.trim().toLowerCase());',
+					'\tconst normalizedDebouncedSearch = computed(() => debouncedSearch.value.trim().toLowerCase());',
+					'',
+					'\treturn { normalizedSearch, normalizedDebouncedSearch };',
+					'}',
+					'',
+				].join('\n'),
+			},
 		async (dir) => {
-			run(process.execPath, [tsx, script, 'useAppController.ts'], dir);
-			run(process.execPath, [tsx, script, 'useAppController.ts'], dir);
+				run(process.execPath, [tsx, script, 'useAppController.ts'], dir);
+				run(process.execPath, [tsx, script, 'useAppController.ts'], dir);
 
-			const output = await readFile(join(dir, 'useAppController.ts'), 'utf8');
+				const output = await readFile(join(dir, 'useAppController.ts'), 'utf8');
 
-			assert.doesNotMatch(output, /\);\);/);
-			assert.match(output, /const normalizedDebouncedSearch = computed\(\(\) => debouncedSearch\.value\.trim\(\)\.toLowerCase\(\)\);/);
-		},
+				assert.doesNotMatch(output, /\);\);/);
+				assert.match(output, /const normalizedDebouncedSearch = computed\(\(\) => debouncedSearch\.value\.trim\(\)\.toLowerCase\(\)\);/);
+			},
 	);
 });
 
 test('ignores untracked ignored files and declaration files', async () => {
 	await withFixture(
 		{
-			'.gitignore': 'ignored.ts\n',
-			'tracked.ts': ['function run() {', '\tconst value = 1;', '\tif (value) return value;', '\treturn 0;', '}', ''].join('\n'),
-			'ignored.ts': ['function run() {', '\tconst value = 1;', '\tif (value) return value;', '}', ''].join('\n'),
-			'types.d.ts': ['declare const value: string;', 'declare function run(): string;', ''].join('\n'),
-		},
+				'.gitignore': 'ignored.ts\n',
+				'tracked.ts': ['function run() {', '\tconst value = 1;', '\tif (value) return value;', '\treturn 0;', '}', ''].join('\n'),
+				'ignored.ts': ['function run() {', '\tconst value = 1;', '\tif (value) return value;', '}', ''].join('\n'),
+				'types.d.ts': ['declare const value: string;', 'declare function run(): string;', ''].join('\n'),
+			},
 		async (dir) => {
-			run(process.execPath, [tsx, script, 'tracked.ts', 'types.d.ts'], dir);
+				run(process.execPath, [tsx, script, 'tracked.ts', 'types.d.ts'], dir);
 
-			const tracked = await readFile(join(dir, 'tracked.ts'), 'utf8');
+				const tracked = await readFile(join(dir, 'tracked.ts'), 'utf8');
 
-			const ignored = await readFile(join(dir, 'ignored.ts'), 'utf8');
+				const ignored = await readFile(join(dir, 'ignored.ts'), 'utf8');
 
-			const types = await readFile(join(dir, 'types.d.ts'), 'utf8');
+				const types = await readFile(join(dir, 'types.d.ts'), 'utf8');
 
-			assert.match(tracked, /const value = 1;\n\n\tif \(value\) \{\n\t\treturn value;\n\t\}\n\n\treturn 0;/);
-			assert.doesNotMatch(ignored, /const value = 1;\n\n\tif/);
-			assert.doesNotMatch(types, /value: string;\n\ndeclare function/);
-		},
+				assert.match(tracked, /const value = 1;\n\n\tif \(value\) \{\n\t\treturn value;\n\t\}\n\n\treturn 0;/);
+				assert.doesNotMatch(ignored, /const value = 1;\n\n\tif/);
+				assert.doesNotMatch(types, /value: string;\n\ndeclare function/);
+			},
 	);
 });
 
 test('skips tracked files missing from the working tree', async () => {
 	await withFixture(
 		{
-			'deleted.ts': ['function run() {', '\tconst value = 1;', '\treturn value;', '}', ''].join('\n'),
-			'kept.ts': ['function run() {', '\tconst value = 1;', '\treturn value;', '}', ''].join('\n'),
-		},
+				'deleted.ts': ['function run() {', '\tconst value = 1;', '\treturn value;', '}', ''].join('\n'),
+				'kept.ts': ['function run() {', '\tconst value = 1;', '\treturn value;', '}', ''].join('\n'),
+			},
 		async (dir) => {
-			await unlink(join(dir, 'deleted.ts'));
+				await unlink(join(dir, 'deleted.ts'));
 
-			run(process.execPath, [tsx, script, 'deleted.ts', 'kept.ts'], dir);
+				run(process.execPath, [tsx, script, 'deleted.ts', 'kept.ts'], dir);
 
-			const kept = await readFile(join(dir, 'kept.ts'), 'utf8');
+				const kept = await readFile(join(dir, 'kept.ts'), 'utf8');
 
-			assert.match(kept, /const value = 1;\n\n\treturn value;/);
-		},
+				assert.match(kept, /const value = 1;\n\n\treturn value;/);
+			},
 	);
 });
 
 test('adds blank lines above loops after simple statements only', async () => {
 	await withFixture(
 		{
-			'loops.ts': [
-				'function run(items: string[], map: Record<string, string>) {',
-				'\tlet count = 0;',
-				'\tcount++;',
-				'\tfor (; count < 1; count++) {',
-				'\t\tcount++;',
-				'\t}',
-				'\tcount++;',
-				'\tfor (const item of items) {',
-				'\t\tconsole.log(item);',
-				'\t}',
-				'\tcount++;',
-				'\tfor (const key in map) {',
-				'\t\tconsole.log(key);',
-				'\t}',
-				'\tcount++;',
-				'\twhile (count < 3) {',
-				'\t\tcount++;',
-				'\t}',
-				'\tcount++;',
-				'\tdo {',
-				'\t\tcount++;',
-				'\t} while (count < 4);',
-				'\tfunction local() {',
-				'\t\treturn count;',
-				'\t}',
-				'\tfor (; count < local(); count++) {',
-				'\t\tcount++;',
-				'\t}',
-				'\tif (count > 10) {',
-				'\t\tcount--;',
-				'\t}',
-				'\twhile (count > 0) {',
-				'\t\tcount--;',
-				'\t}',
-				'\ttype LoopCount = number;',
-				'\twhile (count < Number.MAX_SAFE_INTEGER) {',
-				'\t\tconst typedCount: LoopCount = count;',
-				'\t\tcount = typedCount + 1;',
-				'\t}',
-				'}',
-				'',
-			].join('\n'),
-		},
+				'loops.ts': [
+					'function run(items: string[], map: Record<string, string>) {',
+					'\tlet count = 0;',
+					'\tcount++;',
+					'\tfor (; count < 1; count++) {',
+					'\t\tcount++;',
+					'\t}',
+					'\tcount++;',
+					'\tfor (const item of items) {',
+					'\t\tconsole.log(item);',
+					'\t}',
+					'\tcount++;',
+					'\tfor (const key in map) {',
+					'\t\tconsole.log(key);',
+					'\t}',
+					'\tcount++;',
+					'\twhile (count < 3) {',
+					'\t\tcount++;',
+					'\t}',
+					'\tcount++;',
+					'\tdo {',
+					'\t\tcount++;',
+					'\t} while (count < 4);',
+					'\tfunction local() {',
+					'\t\treturn count;',
+					'\t}',
+					'\tfor (; count < local(); count++) {',
+					'\t\tcount++;',
+					'\t}',
+					'\tif (count > 10) {',
+					'\t\tcount--;',
+					'\t}',
+					'\twhile (count > 0) {',
+					'\t\tcount--;',
+					'\t}',
+					'\ttype LoopCount = number;',
+					'\twhile (count < Number.MAX_SAFE_INTEGER) {',
+					'\t\tconst typedCount: LoopCount = count;',
+					'\t\tcount = typedCount + 1;',
+					'\t}',
+					'}',
+					'',
+				].join('\n'),
+			},
 		async (dir) => {
-			run(process.execPath, [tsx, script, 'loops.ts'], dir);
-			run(process.execPath, [tsx, script, 'loops.ts'], dir);
+				run(process.execPath, [tsx, script, 'loops.ts'], dir);
+				run(process.execPath, [tsx, script, 'loops.ts'], dir);
 
-			const output = await readFile(join(dir, 'loops.ts'), 'utf8');
+				const output = await readFile(join(dir, 'loops.ts'), 'utf8');
 
-			assert.match(output, /count\+\+;\n\n\tfor \(; count < 1; count\+\+\) \{/);
-			assert.match(output, /count\+\+;\n\n\tfor \(const item of items\) \{/);
-			assert.match(output, /count\+\+;\n\n\tfor \(const key in map\) \{/);
-			assert.match(output, /count\+\+;\n\n\twhile \(count < 3\) \{/);
-			assert.match(output, /count\+\+;\n\n\tdo \{/);
-			assert.match(output, /function local\(\) \{\n\t\treturn count;\n\t}\n\tfor \(; count < local\(\); count\+\+\) \{/);
-			assert.match(output, /if \(count > 10\) \{\n\t\tcount--;\n\t}\n\twhile \(count > 0\) \{/);
-			assert.match(output, /type LoopCount = number;\n\n\twhile \(count < Number\.MAX_SAFE_INTEGER\) \{/);
-		},
+				assert.match(output, /count\+\+;\n\n\tfor \(; count < 1; count\+\+\) \{/);
+				assert.match(output, /count\+\+;\n\n\tfor \(const item of items\) \{/);
+				assert.match(output, /count\+\+;\n\n\tfor \(const key in map\) \{/);
+				assert.match(output, /count\+\+;\n\n\twhile \(count < 3\) \{/);
+				assert.match(output, /count\+\+;\n\n\tdo \{/);
+				assert.match(output, /function local\(\) \{\n\t\treturn count;\n\t}\n\tfor \(; count < local\(\); count\+\+\) \{/);
+				assert.match(output, /if \(count > 10\) \{\n\t\tcount--;\n\t}\n\twhile \(count > 0\) \{/);
+				assert.match(output, /type LoopCount = number;\n\n\twhile \(count < Number\.MAX_SAFE_INTEGER\) \{/);
+			},
 	);
 });
 
 test('CLI uses modular formatter for body wrapping and declaration ordering', async () => {
 	await withFixture(
 		{
-			'tracked.ts': ['import {', '\ta,', '} from "a";', 'import { b } from "b";', 'function run() {', '\tif (ready) done();', '}', ''].join('\n'),
-		},
+				'tracked.ts': ['import {', '\ta,', '} from "a";', 'import { b } from "b";', 'function run() {', '\tif (ready) done();', '}', ''].join('\n'),
+			},
 		async (dir) => {
-			run(process.execPath, [tsx, script, 'tracked.ts'], dir);
+				run(process.execPath, [tsx, script, 'tracked.ts'], dir);
 
-			const tracked = await readFile(join(dir, 'tracked.ts'), 'utf8');
+				const tracked = await readFile(join(dir, 'tracked.ts'), 'utf8');
 
-			assert.match(tracked, /import \{ b \} from "b";\n\nimport \{\n\ta,\n\} from "a";/);
-			assert.match(tracked, /if \(ready\) \{\n\t\tdone\(\);\n\t\}/);
-		},
+				assert.match(tracked, /import \{ b \} from "b";\n\nimport \{\n\ta,\n\} from "a";/);
+				assert.match(tracked, /if \(ready\) \{\n\t\tdone\(\);\n\t\}/);
+			},
 	);
 });

--- a/packages/devx/scripts/class-reorder.ts
+++ b/packages/devx/scripts/class-reorder.ts
@@ -13,7 +13,9 @@ function hasCommentsAroundMembers(source: string, body: Node, members: Node[]): 
 	const firstStart = getStart(members[0]);
 	const lastEnd = getEnd(members[members.length - 1]);
 
-	if (containsComment(source.slice(bodyStart + 1, firstStart))) {
+	if (containsComment(
+		source.slice(bodyStart + 1, firstStart),
+	)) {
 		return true;
 	}
 
@@ -25,7 +27,9 @@ function hasCommentsAroundMembers(source: string, body: Node, members: Node[]): 
 		}
 	}
 
-	return containsComment(source.slice(lastEnd, bodyEnd - 1));
+	return containsComment(
+		source.slice(lastEnd, bodyEnd - 1),
+	);
 }
 
 function computeClassReorderEdit(source: string, body: Node): Edit | null {

--- a/packages/devx/scripts/declaration-reorder.ts
+++ b/packages/devx/scripts/declaration-reorder.ts
@@ -153,7 +153,9 @@ function canReorderConstGroup(source: string, group: Node[]): boolean {
 			continue;
 		}
 
-		const names = declaredNames([group[i]]);
+		const names = declaredNames(
+			[group[i]],
+		);
 
 		if (
 			group.slice(i + 1).some((node) => {
@@ -216,7 +218,10 @@ function groupEdit(source: string, group: Node[], canReorder: boolean): Edit | n
 		.join('');
 
 	const firstStart = getStart(group[0]);
-	const lastEnd = getEnd(group.at(-1)!);
+
+	const lastEnd = getEnd(
+		group.at(-1)!,
+	);
 
 	if (firstStart < 0 || lastEnd < 0) {
 		return null;
@@ -270,7 +275,11 @@ export function computeDeclarationReorderEdits(content: string, virtualName: str
 		}
 
 		for (const group of constGroups) {
-			const edit = groupEdit(content, group, canReorderConstGroup(content, group));
+			const edit = groupEdit(
+				content,
+				group,
+				canReorderConstGroup(content, group),
+			);
 
 			if (edit) {
 				edits.push(edit);

--- a/packages/devx/scripts/drizzle-queries.ts
+++ b/packages/devx/scripts/drizzle-queries.ts
@@ -325,7 +325,11 @@ function callDisplayName(source: string, call: Node, imports: DrizzleImports): s
 }
 
 function callParens(source: string, call: Node): { open: number; close: number } | null {
-	return sharedCallParens(source, call, unwrapChainExpression(call.callee as Node | undefined));
+	return sharedCallParens(
+		source,
+		call,
+		unwrapChainExpression(call.callee as Node | undefined),
+	);
 }
 
 function shouldFormatObjectExpression(node: Node): boolean {
@@ -422,7 +426,11 @@ function shouldFormatMethodArguments(call: Node, imports: DrizzleImports): boole
 }
 
 function formatArrayExpression(source: string, node: Node, imports: DrizzleImports, comments: Node[], indent: string): string {
-	if (hasCommentBetween(comments, getStart(node), getEnd(node))) {
+	if (hasCommentBetween(
+		comments,
+		getStart(node),
+		getEnd(node),
+	)) {
 		return sourceOf(source, node);
 	}
 
@@ -442,7 +450,11 @@ function formatArrayExpression(source: string, node: Node, imports: DrizzleImpor
 }
 
 function formatObjectExpression(source: string, node: Node, imports: DrizzleImports, comments: Node[], indent: string): string {
-	if (hasCommentBetween(comments, getStart(node), getEnd(node))) {
+	if (hasCommentBetween(
+		comments,
+		getStart(node),
+		getEnd(node),
+	)) {
 		return sourceOf(source, node);
 	}
 
@@ -477,11 +489,18 @@ function formatObjectExpression(source: string, node: Node, imports: DrizzleImpo
 }
 
 function formatHelperCall(source: string, call: Node, imports: DrizzleImports, comments: Node[], indent: string): string {
-	if (hasCommentBetween(comments, getStart(call), getEnd(call))) {
+	if (hasCommentBetween(
+		comments,
+		getStart(call),
+		getEnd(call),
+	)) {
 		return sourceOf(source, call);
 	}
 
-	const importedName = calleeName(unwrapChainExpression(call.callee as Node | undefined), imports);
+	const importedName = calleeName(
+		unwrapChainExpression(call.callee as Node | undefined),
+		imports,
+	);
 
 	const args = Array.isArray(call.arguments) ? (call.arguments as Node[]) : [];
 
@@ -496,7 +515,11 @@ function formatHelperCall(source: string, call: Node, imports: DrizzleImports, c
 }
 
 function formatSetOperationCall(source: string, call: Node, imports: DrizzleImports, comments: Node[], indent: string): string {
-	if (hasCommentBetween(comments, getStart(call), getEnd(call))) {
+	if (hasCommentBetween(
+		comments,
+		getStart(call),
+		getEnd(call),
+	)) {
 		return sourceOf(source, call);
 	}
 

--- a/packages/devx/scripts/expanded-calls.test.ts
+++ b/packages/devx/scripts/expanded-calls.test.ts
@@ -64,4 +64,14 @@ describe('expanded call formatter', () => {
 
 		assert.equal(formatExpandedCalls(input, 'types.d.ts'), input);
 	});
+
+	it('re-indents a multiline object argument to its new depth', () => {
+		// The object's inner lines were written against the statement's indent.
+		// Expanding pushes the object one level deeper, so they have to move with
+		// it — oxfmt used to hide this by collapsing the call straight back.
+		const input = ['function send() {', '\tconst response = fetch(url, {', '\t\t...init,', '\t\theaders,', '\t});', '}', ''].join('\n');
+		const expected = ['function send() {', '\tconst response = fetch(', '\t\turl,', '\t\t{', '\t\t\t...init,', '\t\t\theaders,', '\t\t},', '\t);', '}', ''].join('\n');
+
+		assert.equal(formatExpandedCalls(input, 'fixture.ts'), expected);
+	});
 });

--- a/packages/devx/scripts/expanded-calls.ts
+++ b/packages/devx/scripts/expanded-calls.ts
@@ -114,7 +114,38 @@ function canUseTrailingComma(arg: Node | undefined): boolean {
 	return arg?.type !== 'SpreadElement';
 }
 
-function formatCallParens(source: string, call: Node, comments: Node[], indent: string): string | null {
+/**
+ * Re-indent lifted source so its continuation lines match where it now sits.
+ *
+ * An argument's text is copied out of the call site verbatim, so its second and
+ * later lines are still indented relative to the statement the call started on
+ * (`from`). Expanding the call moves the argument one or more levels deeper
+ * (`to`), and without rebasing those lines they keep the shallower depth and the
+ * block reads inside-out. Only the first line is left alone — the caller places
+ * it.
+ */
+function rebaseIndent(text: string, from: string, to: string): string {
+	if (from === to || !text.includes('\n')) {
+		return text;
+	}
+
+	return text
+		.split('\n')
+		.map((line, index) => {
+			if (index === 0) {
+				return line;
+			}
+
+			if (line.trim() === '') {
+				return '';
+			}
+
+			return line.startsWith(from) ? `${to}${line.slice(from.length)}` : line;
+		})
+		.join('\n');
+}
+
+function formatCallParens(source: string, call: Node, comments: Node[], indent: string, baseIndent: string): string | null {
 	const parens = calleeParens(source, call);
 	const args = callArguments(call);
 
@@ -129,7 +160,7 @@ function formatCallParens(source: string, call: Node, comments: Node[], indent: 
 	const argIndent = `${indent}\t`;
 
 	const formattedArgs = args.map((arg) => {
-		return formatNode(source, arg, comments, argIndent);
+		return formatNode(source, arg, comments, argIndent, baseIndent);
 	});
 
 	const separator = `,\n${argIndent}`;
@@ -138,27 +169,30 @@ function formatCallParens(source: string, call: Node, comments: Node[], indent: 
 	return `(\n${argIndent}${formattedArgs.join(separator)}${trailingComma}\n${indent})`;
 }
 
-function formatCall(source: string, call: Node, comments: Node[], indent: string): string {
+function formatCall(source: string, call: Node, comments: Node[], indent: string, baseIndent: string): string {
 	const parens = calleeParens(source, call);
-	const formattedParens = formatCallParens(source, call, comments, indent);
+	const formattedParens = formatCallParens(source, call, comments, indent, baseIndent);
 
 	if (!parens || formattedParens === null) {
-		return sourceOf(source, call);
+		return rebaseIndent(sourceOf(source, call), baseIndent, indent);
 	}
 
 	return `${source.slice(getStart(call), parens.open)}${formattedParens}`;
 }
 
-function formatNode(source: string, node: Node, comments: Node[], indent: string): string {
+// indent is where node will sit once expanded; baseIndent is where its source
+// text came from and is threaded down unchanged, because nothing has moved in
+// the source yet however deep the recursion goes.
+function formatNode(source: string, node: Node, comments: Node[], indent: string, baseIndent: string): string {
 	if (node.type !== 'CallExpression') {
-		return sourceOf(source, node);
+		return rebaseIndent(sourceOf(source, node), baseIndent, indent);
 	}
 
 	if (!shouldExpandCall(node)) {
-		return sourceOf(source, node);
+		return rebaseIndent(sourceOf(source, node), baseIndent, indent);
 	}
 
-	return formatCall(source, node, comments, indent);
+	return formatCall(source, node, comments, indent, baseIndent);
 }
 
 export function computeExpandedCallEdits(content: string, virtualName: string): Edit[] {
@@ -199,7 +233,9 @@ export function computeExpandedCallEdits(content: string, virtualName: string): 
 
 		const indent = lineIndent(content, getStart(node));
 
-		const replacement = formatCallParens(content, node, comments, indent);
+		// The call has not moved, so every argument's source is still based at
+		// this statement's indent — that is what nested levels rebase away from.
+		const replacement = formatCallParens(content, node, comments, indent, indent);
 		const current = content.slice(parens.open, parens.close + 1);
 
 		if (replacement === null || replacement === current) {

--- a/packages/devx/scripts/expanded-calls.ts
+++ b/packages/devx/scripts/expanded-calls.ts
@@ -25,7 +25,11 @@ function unwrapExpression(node: Node | undefined): Node | undefined {
 }
 
 function calleeParens(source: string, call: Node): CallParens | null {
-	return callParens(source, call, unwrapExpression(call.callee as Node | undefined));
+	return callParens(
+		source,
+		call,
+		unwrapExpression(call.callee as Node | undefined),
+	);
 }
 
 function callArguments(call: Node): Node[] {
@@ -164,7 +168,10 @@ function formatCallParens(source: string, call: Node, comments: Node[], indent: 
 	});
 
 	const separator = `,\n${argIndent}`;
-	const trailingComma = canUseTrailingComma(args.at(-1)) ? ',' : '';
+
+	const trailingComma = canUseTrailingComma(
+		args.at(-1),
+	) ? ',' : '';
 
 	return `(\n${argIndent}${formattedArgs.join(separator)}${trailingComma}\n${indent})`;
 }
@@ -174,7 +181,11 @@ function formatCall(source: string, call: Node, comments: Node[], indent: string
 	const formattedParens = formatCallParens(source, call, comments, indent, baseIndent);
 
 	if (!parens || formattedParens === null) {
-		return rebaseIndent(sourceOf(source, call), baseIndent, indent);
+		return rebaseIndent(
+			sourceOf(source, call),
+			baseIndent,
+			indent,
+		);
 	}
 
 	return `${source.slice(getStart(call), parens.open)}${formattedParens}`;
@@ -185,11 +196,19 @@ function formatCall(source: string, call: Node, comments: Node[], indent: string
 // the source yet however deep the recursion goes.
 function formatNode(source: string, node: Node, comments: Node[], indent: string, baseIndent: string): string {
 	if (node.type !== 'CallExpression') {
-		return rebaseIndent(sourceOf(source, node), baseIndent, indent);
+		return rebaseIndent(
+			sourceOf(source, node),
+			baseIndent,
+			indent,
+		);
 	}
 
 	if (!shouldExpandCall(node)) {
-		return rebaseIndent(sourceOf(source, node), baseIndent, indent);
+		return rebaseIndent(
+			sourceOf(source, node),
+			baseIndent,
+			indent,
+		);
 	}
 
 	return formatCall(source, node, comments, indent, baseIndent);
@@ -231,10 +250,11 @@ export function computeExpandedCallEdits(content: string, virtualName: string): 
 			return;
 		}
 
-		const indent = lineIndent(content, getStart(node));
+		const indent = lineIndent(
+			content,
+			getStart(node),
+		);
 
-		// The call has not moved, so every argument's source is still based at
-		// this statement's indent — that is what nested levels rebase away from.
 		const replacement = formatCallParens(content, node, comments, indent, indent);
 		const current = content.slice(parens.open, parens.close + 1);
 

--- a/packages/devx/scripts/files.ts
+++ b/packages/devx/scripts/files.ts
@@ -14,7 +14,10 @@ export async function dirExists(dir: string): Promise<boolean> {
 }
 
 export async function listSourceFiles(dir: string): Promise<string[]> {
-	const entries = await readdir(dir, { recursive: true, withFileTypes: true });
+	const entries = await readdir(
+		dir,
+		{ recursive: true, withFileTypes: true },
+	);
 
 	const files: string[] = [];
 

--- a/packages/devx/scripts/fluent-chains.test.ts
+++ b/packages/devx/scripts/fluent-chains.test.ts
@@ -7,26 +7,45 @@ import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { formatFluentChains } from '#devx/fluent-chains';
 
-const script = fileURLToPath(import.meta.resolve('#devx/fluent-chains'));
-const tsx = fileURLToPath(import.meta.resolve('tsx/cli'));
+const script = fileURLToPath(
+	import.meta.resolve('#devx/fluent-chains'),
+);
+const tsx = fileURLToPath(
+	import.meta.resolve('tsx/cli'),
+);
 
 function run(command: string, args: string[], cwd: string): void {
-	const result = spawnSync(command, args, { cwd, encoding: 'utf8' });
+	const result = spawnSync(
+		command,
+		args,
+		{ cwd, encoding: 'utf8' },
+	);
 
 	assert.equal(result.status, 0, result.stderr || result.stdout);
 }
 
 async function withFixture(files: Record<string, string>, fn: (dir: string) => Promise<void>): Promise<void> {
-	const dir = await mkdtemp(join(tmpdir(), 'fmtkit-fluent-chains-'));
+	const dir = await mkdtemp(
+		join(
+			tmpdir(),
+			'fmtkit-fluent-chains-',
+		),
+	);
 
 	try {
 		for (const [file, content] of Object.entries(files)) {
-			await writeFile(join(dir, file), content);
+			await writeFile(
+				join(dir, file),
+				content,
+			);
 		}
 
 		await fn(dir);
 	} finally {
-		await rm(dir, { recursive: true, force: true });
+		await rm(
+			dir,
+			{ recursive: true, force: true },
+		);
 	}
 }
 
@@ -84,22 +103,22 @@ describe('fluent chain formatter', () => {
 	it('formats Vue script blocks through the CLI', async () => {
 		await withFixture(
 			{
-				'DashboardRoute.vue': [
-					'<script setup lang="ts">',
-					"export const meRoutes = createRouter<{ Bindings: WorkerEnv; Variables: IdentityVariables }>().use('*', bindEnv).use(identityMiddleware).get('/', getMe).get('/sessions', getSessions);",
-					'</script>',
-					'',
-				].join('\n'),
-			},
+					'DashboardRoute.vue': [
+						'<script setup lang="ts">',
+						"export const meRoutes = createRouter<{ Bindings: WorkerEnv; Variables: IdentityVariables }>().use('*', bindEnv).use(identityMiddleware).get('/', getMe).get('/sessions', getSessions);",
+						'</script>',
+						'',
+					].join('\n'),
+				},
 			async (dir) => {
-				run(process.execPath, [tsx, script, 'DashboardRoute.vue'], dir);
-				run(process.execPath, [tsx, script, 'DashboardRoute.vue'], dir);
+					run(process.execPath, [tsx, script, 'DashboardRoute.vue'], dir);
+					run(process.execPath, [tsx, script, 'DashboardRoute.vue'], dir);
 
-				const output = await readFile(join(dir, 'DashboardRoute.vue'), 'utf8');
+					const output = await readFile(join(dir, 'DashboardRoute.vue'), 'utf8');
 
-				assert.match(output, /createRouter<\{ Bindings: WorkerEnv; Variables: IdentityVariables \}>\(\)\n\t\.use\('\*', bindEnv\)\n\t\.use\(identityMiddleware\)/);
-				assert.match(output, /\.get\('\/', getMe\)\n\t\.get\('\/sessions', getSessions\);/);
-			},
+					assert.match(output, /createRouter<\{ Bindings: WorkerEnv; Variables: IdentityVariables \}>\(\)\n\t\.use\('\*', bindEnv\)\n\t\.use\(identityMiddleware\)/);
+					assert.match(output, /\.get\('\/', getMe\)\n\t\.get\('\/sessions', getSessions\);/);
+				},
 		);
 	});
 
@@ -108,69 +127,69 @@ describe('fluent chain formatter', () => {
 
 		await withFixture(
 			{
-				'StructuredData.vue': [
-					'<script type="application/ld+json">',
-					jsonLd,
-					'</script>',
-					'<script setup lang="ts">',
-					"export const meRoutes = createRouter().use('*', bindEnv).get('/', getMe);",
-					'</script>',
-					'',
-				].join('\n'),
-			},
+					'StructuredData.vue': [
+						'<script type="application/ld+json">',
+						jsonLd,
+						'</script>',
+						'<script setup lang="ts">',
+						"export const meRoutes = createRouter().use('*', bindEnv).get('/', getMe);",
+						'</script>',
+						'',
+					].join('\n'),
+				},
 			async (dir) => {
-				run(process.execPath, [tsx, script, 'StructuredData.vue'], dir);
+					run(process.execPath, [tsx, script, 'StructuredData.vue'], dir);
 
-				const output = await readFile(join(dir, 'StructuredData.vue'), 'utf8');
+					const output = await readFile(join(dir, 'StructuredData.vue'), 'utf8');
 
-				assert.ok(output.includes(['<script type="application/ld+json">', jsonLd, '</script>'].join('\n')));
-				assert.match(output, /createRouter\(\)\n\t\.use\('\*', bindEnv\)\n\t\.get\('\/', getMe\);/);
-			},
+					assert.ok(output.includes(['<script type="application/ld+json">', jsonLd, '</script>'].join('\n')));
+					assert.match(output, /createRouter\(\)\n\t\.use\('\*', bindEnv\)\n\t\.get\('\/', getMe\);/);
+				},
 		);
 	});
 
 	it('formats Drizzle queries in Vue script blocks through the CLI', async () => {
 		await withFixture(
 			{
-				'DashboardData.vue': [
-					'<script setup lang="ts">',
-					"import { and, eq, gt } from 'drizzle-orm';",
-					'const rows = await db.select().from(sessions).where(and(eq(sessions.userId, userId), gt(sessions.expiresAt, now)));',
-					'</script>',
-					'',
-				].join('\n'),
-			},
+					'DashboardData.vue': [
+						'<script setup lang="ts">',
+						"import { and, eq, gt } from 'drizzle-orm';",
+						'const rows = await db.select().from(sessions).where(and(eq(sessions.userId, userId), gt(sessions.expiresAt, now)));',
+						'</script>',
+						'',
+					].join('\n'),
+				},
 			async (dir) => {
-				run(process.execPath, [tsx, script, 'DashboardData.vue'], dir);
-				run(process.execPath, [tsx, script, 'DashboardData.vue'], dir);
+					run(process.execPath, [tsx, script, 'DashboardData.vue'], dir);
+					run(process.execPath, [tsx, script, 'DashboardData.vue'], dir);
 
-				const output = await readFile(join(dir, 'DashboardData.vue'), 'utf8');
+					const output = await readFile(join(dir, 'DashboardData.vue'), 'utf8');
 
-				assert.match(output, /\.where\(\n\t\tand\(\n\t\t\teq\(sessions\.userId, userId\),\n\t\t\tgt\(sessions\.expiresAt, now\),\n\t\t\),\n\t\);/);
-			},
+					assert.match(output, /\.where\(\n\t\tand\(\n\t\t\teq\(sessions\.userId, userId\),\n\t\t\tgt\(sessions\.expiresAt, now\),\n\t\t\),\n\t\);/);
+				},
 		);
 	});
 
 	it('formats expanded call arguments in Vue script blocks through the CLI', async () => {
 		await withFixture(
 			{
-				'AuthProvider.vue': [
-					'<script setup lang="ts">',
-					'function createAuth() {',
-					'\treturn betterAuth(buildAuthConfig(env, db, mailer, app, options)) as unknown as SasuAuth;',
-					'}',
-					'</script>',
-					'',
-				].join('\n'),
-			},
+					'AuthProvider.vue': [
+						'<script setup lang="ts">',
+						'function createAuth() {',
+						'\treturn betterAuth(buildAuthConfig(env, db, mailer, app, options)) as unknown as SasuAuth;',
+						'}',
+						'</script>',
+						'',
+					].join('\n'),
+				},
 			async (dir) => {
-				run(process.execPath, [tsx, script, 'AuthProvider.vue'], dir);
-				run(process.execPath, [tsx, script, 'AuthProvider.vue'], dir);
+					run(process.execPath, [tsx, script, 'AuthProvider.vue'], dir);
+					run(process.execPath, [tsx, script, 'AuthProvider.vue'], dir);
 
-				const output = await readFile(join(dir, 'AuthProvider.vue'), 'utf8');
+					const output = await readFile(join(dir, 'AuthProvider.vue'), 'utf8');
 
-				assert.match(output, /return betterAuth\(\n\t\tbuildAuthConfig\(env, db, mailer, app, options\),\n\t\) as unknown as SasuAuth;/);
-			},
+					assert.match(output, /return betterAuth\(\n\t\tbuildAuthConfig\(env, db, mailer, app, options\),\n\t\) as unknown as SasuAuth;/);
+				},
 		);
 	});
 });

--- a/packages/devx/scripts/format-all.test.ts
+++ b/packages/devx/scripts/format-all.test.ts
@@ -12,7 +12,9 @@ const tsxBin = resolve(import.meta.dirname, '../node_modules/.bin/tsx');
 const formatAllScript = resolve(import.meta.dirname, 'format-all.ts');
 
 test('parseArgs splits flags and file sections', () => {
-	const options = parseArgs(['--check', '--oxfmt-bin', '/bin/oxfmt', '--oxfmt-config', '/etc/oxfmtrc.json', '--format-files', 'a.ts', 'b.vue', '--syntax-files', 'a.ts', 'types.d.ts']);
+	const options = parseArgs(
+		['--check', '--oxfmt-bin', '/bin/oxfmt', '--oxfmt-config', '/etc/oxfmtrc.json', '--format-files', 'a.ts', 'b.vue', '--syntax-files', 'a.ts', 'types.d.ts'],
+	);
 
 	assert.deepEqual(options, {
 		check: true,
@@ -24,14 +26,18 @@ test('parseArgs splits flags and file sections', () => {
 });
 
 test('parseArgs accepts empty file sections and rejects stray arguments', () => {
-	const options = parseArgs(['--format-files', '--syntax-files']);
+	const options = parseArgs(
+		['--format-files', '--syntax-files'],
+	);
 
 	assert.deepEqual(options.formatFiles, []);
 
 	assert.deepEqual(options.syntaxFiles, []);
 
 	assert.throws(() => {
-		return parseArgs(['stray.ts']);
+		return parseArgs(
+			['stray.ts'],
+		);
 	}, /unexpected argument/);
 });
 
@@ -70,39 +76,57 @@ test('mapPool processes every item, preserves order, and honors the limit', asyn
 test('runPass processes every file and skips missing ones', async () => {
 	const seen: string[] = [];
 
-	await runPass('blank-lines', ['a.ts', 'missing.ts', 'b.ts'], false, async (file) => {
-		if (file === 'missing.ts') {
-			throw Object.assign(new Error('gone'), { code: 'ENOENT' });
-		}
+	await runPass(
+		'blank-lines',
+		['a.ts', 'missing.ts', 'b.ts'],
+		false,
+		async (file) => {
+			if (file === 'missing.ts') {
+				throw Object.assign(new Error('gone'), { code: 'ENOENT' });
+			}
 
-		seen.push(file);
+			seen.push(file);
 
-		return true;
-	});
+			return true;
+		},
+	);
 
 	assert.deepEqual(seen.sort(), ['a.ts', 'b.ts']);
 });
 
 test('runOxfmt resolves without spawning when no binary or no files are given', async () => {
-	await runOxfmt({ check: false, oxfmtBin: null, oxfmtConfig: null, formatFiles: ['a.ts'], syntaxFiles: [] });
+	await runOxfmt(
+		{ check: false, oxfmtBin: null, oxfmtConfig: null, formatFiles: ['a.ts'], syntaxFiles: [] },
+	);
 
-	await runOxfmt({ check: false, oxfmtBin: 'false', oxfmtConfig: null, formatFiles: [], syntaxFiles: [] });
+	await runOxfmt(
+		{ check: false, oxfmtBin: 'false', oxfmtConfig: null, formatFiles: [], syntaxFiles: [] },
+	);
 });
 
 test('runOxfmt spawns with --check in check mode and surfaces failures', async () => {
-	await runOxfmt({ check: true, oxfmtBin: 'true', oxfmtConfig: null, formatFiles: ['a.ts'], syntaxFiles: [] });
+	await runOxfmt(
+		{ check: true, oxfmtBin: 'true', oxfmtConfig: null, formatFiles: ['a.ts'], syntaxFiles: [] },
+	);
 
 	await assert.rejects(runOxfmt({ check: true, oxfmtBin: 'false', oxfmtConfig: null, formatFiles: ['a.ts'], syntaxFiles: [] }), /oxfmt exited/);
 });
 
 test('runOxfmt surfaces the exit status of the spawned formatter', async () => {
-	await runOxfmt({ check: false, oxfmtBin: 'true', oxfmtConfig: null, formatFiles: ['a.ts'], syntaxFiles: [] });
+	await runOxfmt(
+		{ check: false, oxfmtBin: 'true', oxfmtConfig: null, formatFiles: ['a.ts'], syntaxFiles: [] },
+	);
 
 	await assert.rejects(runOxfmt({ check: false, oxfmtBin: 'false', oxfmtConfig: null, formatFiles: ['a.ts'], syntaxFiles: [] }), /oxfmt exited/);
 });
 
 test('runOxfmt chunks large file lists', async () => {
-	const dir = await mkdtemp(join(tmpdir(), 'fmtkit-devx-oxfmt-chunks-'));
+	const dir = await mkdtemp(
+		join(
+			tmpdir(),
+			'fmtkit-devx-oxfmt-chunks-',
+		),
+	);
 
 	try {
 		const bin = join(dir, 'oxfmt');
@@ -121,23 +145,36 @@ printf '%s\\n' "$#" >> "${log}"
 
 		await chmod(bin, 0o755);
 
-		await runOxfmt({ check: false, oxfmtBin: bin, oxfmtConfig: null, formatFiles: files, syntaxFiles: [] });
+		await runOxfmt(
+			{ check: false, oxfmtBin: bin, oxfmtConfig: null, formatFiles: files, syntaxFiles: [] },
+		);
 
 		assert.deepEqual((await readFile(log, 'utf8')).trim().split('\n'), ['102', '102', '7']);
 	} finally {
-		await rm(dir, { recursive: true, force: true });
+		await rm(
+			dir,
+			{ recursive: true, force: true },
+		);
 	}
 });
 
 test('format-all pipeline formats files and exits 0 end-to-end', async () => {
-	const dir = await mkdtemp(join(tmpdir(), 'fmtkit-devx-format-all-'));
+	const dir = await mkdtemp(
+		join(
+			tmpdir(),
+			'fmtkit-devx-format-all-',
+		),
+	);
 
 	try {
 		const file = join(dir, 'app.ts');
 
 		await writeFile(file, 'function run() {\n\tconst x = 1;\n\tif (x) return x;\n\treturn 0;\n}\n');
 
-		const { stdout } = await execFileAsync(tsxBin, [formatAllScript, '--format-files', file, '--syntax-files', file]);
+		const { stdout } = await execFileAsync(
+			tsxBin,
+			[formatAllScript, '--format-files', file, '--syntax-files', file],
+		);
 
 		const updated = await readFile(file, 'utf8');
 
@@ -149,30 +186,49 @@ test('format-all pipeline formats files and exits 0 end-to-end', async () => {
 
 		assert.ok(blankIndex >= 0 && fluentIndex > blankIndex && validateIndex > fluentIndex, `unexpected pass order:\n${stdout}`);
 	} finally {
-		await rm(dir, { recursive: true, force: true });
+		await rm(
+			dir,
+			{ recursive: true, force: true },
+		);
 	}
 });
 
 test('format-all pipeline deduplicates repeated input paths', async () => {
-	const dir = await mkdtemp(join(tmpdir(), 'fmtkit-devx-format-all-dup-'));
+	const dir = await mkdtemp(
+		join(
+			tmpdir(),
+			'fmtkit-devx-format-all-dup-',
+		),
+	);
 
 	try {
 		const file = join(dir, 'app.ts');
 
 		await writeFile(file, 'const one = 1;\n');
 
-		const { stdout } = await execFileAsync(tsxBin, [formatAllScript, '--format-files', file, file, '--syntax-files', file, file]);
+		const { stdout } = await execFileAsync(
+			tsxBin,
+			[formatAllScript, '--format-files', file, file, '--syntax-files', file, file],
+		);
 
 		assert.match(stdout, /\[blank-lines\] processed 1 file\(s\)/);
 
 		assert.match(stdout, /\[validate-syntax\] checked 1 file\(s\)/);
 	} finally {
-		await rm(dir, { recursive: true, force: true });
+		await rm(
+			dir,
+			{ recursive: true, force: true },
+		);
 	}
 });
 
 test('format-all pipeline exits 1 when validation finds syntax errors', async () => {
-	const dir = await mkdtemp(join(tmpdir(), 'fmtkit-devx-format-all-bad-'));
+	const dir = await mkdtemp(
+		join(
+			tmpdir(),
+			'fmtkit-devx-format-all-bad-',
+		),
+	);
 
 	try {
 		const file = join(dir, 'broken.ts');
@@ -183,6 +239,9 @@ test('format-all pipeline exits 1 when validation finds syntax errors', async ()
 			return err.code === 1;
 		});
 	} finally {
-		await rm(dir, { recursive: true, force: true });
+		await rm(
+			dir,
+			{ recursive: true, force: true },
+		);
 	}
 });

--- a/packages/devx/scripts/format-all.ts
+++ b/packages/devx/scripts/format-all.ts
@@ -97,17 +97,21 @@ export async function mapPool<T, R>(items: T[], limit: number, fn: (item: T) => 
 }
 
 export async function runPass(label: string, files: string[], check: boolean, processOne: (file: string, check: boolean) => Promise<boolean>): Promise<void> {
-	const outcomes = await mapPool(files, availableParallelism(), async (file): Promise<PassOutcome> => {
-		try {
-			return { file, changed: await processOne(file, check), missing: false };
-		} catch (err) {
-			if (isNotFoundError(err)) {
-				return { file, changed: false, missing: true };
-			}
+	const outcomes = await mapPool(
+		files,
+		availableParallelism(),
+		async (file): Promise<PassOutcome> => {
+			try {
+				return { file, changed: await processOne(file, check), missing: false };
+			} catch (err) {
+				if (isNotFoundError(err)) {
+					return { file, changed: false, missing: true };
+				}
 
-			throw err;
-		}
-	});
+				throw err;
+			}
+		},
+	);
 
 	let changedCount = 0;
 
@@ -148,7 +152,11 @@ export function runOxfmt(options: CliOptions): Promise<void> {
 
 	const runChunk = (chunk: string[]): Promise<void> => {
 		return new Promise((resolvePromise, rejectPromise) => {
-			const child = spawn(bin, [...args, ...chunk], { stdio: 'inherit' });
+			const child = spawn(
+				bin,
+				[...args, ...chunk],
+				{ stdio: 'inherit' },
+			);
 
 			child.on('error', rejectPromise);
 
@@ -176,7 +184,11 @@ export function runOxfmt(options: CliOptions): Promise<void> {
 }
 
 async function runValidate(files: string[]): Promise<void> {
-	const failures = (await mapPool(files, availableParallelism(), validateFile)).flat();
+	const failures = (await mapPool(
+		files,
+		availableParallelism(),
+		validateFile,
+	)).flat();
 
 	if (failures.length > 0) {
 		console.error(failures.join('\n'));
@@ -188,7 +200,10 @@ async function runValidate(files: string[]): Promise<void> {
 }
 
 export async function main(): Promise<void> {
-	const options = parseArgs(process.argv.slice(2));
+	const options = parseArgs(
+		process.argv.slice(2),
+	);
+
 	const formatTargets = [...new Set(options.formatFiles.filter(isTargetFile))];
 
 	const syntaxTargets = [

--- a/packages/devx/scripts/format-all.ts
+++ b/packages/devx/scripts/format-all.ts
@@ -6,10 +6,18 @@ import { processFluentChainsFile } from '#devx/fluent-chains';
 import { isNotFoundError, isTargetFile } from '#devx/pass-utils';
 import { validateFile } from '#devx/validate-syntax';
 
-// format-all runs the full TS pipeline (blank-lines → oxfmt → fluent-chains
-// → oxfmt → validate-syntax) inside a single process. Files within a pass are
-// processed concurrently; results are reported in input order so the output
-// stays deterministic.
+// format-all runs the full TS pipeline (blank-lines → oxfmt → fluent-chains →
+// validate-syntax) inside a single process. Files within a pass are processed
+// concurrently; results are reported in input order so the output stays
+// deterministic.
+//
+// oxfmt runs *before* the project passes, never after. It is an internal step
+// that normalises the file; the project passes then impose the style fmtkit
+// actually ships. Re-running oxfmt at the end would undo them — it collapses
+// anything that fits in printWidth, which is most of what expanded-calls and
+// fluent-chains just expanded. The output is therefore deliberately not what
+// bare oxfmt would produce: fmtkit's format is the pipeline's output, so check
+// it by running the pipeline, not by running oxfmt.
 
 type CliOptions = {
 	check: boolean;
@@ -198,8 +206,6 @@ export async function main(): Promise<void> {
 	await runOxfmt(pipelineOptions);
 
 	await runPass('fluent-chains', formatTargets, options.check, processFluentChainsFile);
-
-	await runOxfmt(pipelineOptions);
 
 	await runValidate(syntaxTargets);
 }

--- a/packages/devx/scripts/pass-utils.test.ts
+++ b/packages/devx/scripts/pass-utils.test.ts
@@ -64,11 +64,13 @@ test('lineIndent returns the leading whitespace of the position line', () => {
 });
 
 test('nonOverlappingEdits drops overlapping edits and sorts by start', () => {
-	const kept = nonOverlappingEdits([
-		{ start: 10, end: 20, replacement: 'b' },
-		{ start: 0, end: 5, replacement: 'a' },
-		{ start: 15, end: 25, replacement: 'c' },
-	]);
+	const kept = nonOverlappingEdits(
+		[
+			{ start: 10, end: 20, replacement: 'b' },
+			{ start: 0, end: 5, replacement: 'a' },
+			{ start: 15, end: 25, replacement: 'c' },
+		],
+	);
 
 	assert.deepEqual(
 		kept.map((edit) => {
@@ -112,7 +114,12 @@ test('isJavaScriptOrTypeScript accepts JS/TS langs and module types, rejects oth
 });
 
 test('writeFileAtomic replaces the file content and leaves no temp files', async () => {
-	const dir = await mkdtemp(join(tmpdir(), 'fmtkit-devx-atomic-'));
+	const dir = await mkdtemp(
+		join(
+			tmpdir(),
+			'fmtkit-devx-atomic-',
+		),
+	);
 
 	try {
 		const file = join(dir, 'target.ts');
@@ -125,6 +132,9 @@ test('writeFileAtomic replaces the file content and leaves no temp files', async
 
 		assert.deepEqual(await readdir(dir), ['target.ts']);
 	} finally {
-		await rm(dir, { recursive: true, force: true });
+		await rm(
+			dir,
+			{ recursive: true, force: true },
+		);
 	}
 });

--- a/packages/devx/scripts/pass-utils.ts
+++ b/packages/devx/scripts/pass-utils.ts
@@ -186,7 +186,10 @@ export async function writeFileAtomic(file: string, content: string): Promise<vo
 		await rename(tmp, file);
 	} catch (err) {
 		try {
-			await rm(tmp, { force: true });
+			await rm(
+				tmp,
+				{ force: true },
+			);
 		} catch {
 			// Ignore cleanup failures so the original write/rename error surfaces.
 		}

--- a/packages/devx/scripts/validate-syntax.test.ts
+++ b/packages/devx/scripts/validate-syntax.test.ts
@@ -6,98 +6,113 @@ import { join } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-const script = fileURLToPath(import.meta.resolve('#devx/validate-syntax'));
-const tsx = fileURLToPath(import.meta.resolve('tsx/cli'));
+const script = fileURLToPath(
+	import.meta.resolve('#devx/validate-syntax'),
+);
+const tsx = fileURLToPath(
+	import.meta.resolve('tsx/cli'),
+);
 
 async function withFixture(files: Record<string, string>, fn: (dir: string) => Promise<void>): Promise<void> {
-	const dir = await mkdtemp(join(tmpdir(), 'fmtkit-validate-syntax-'));
+	const dir = await mkdtemp(
+		join(
+			tmpdir(),
+			'fmtkit-validate-syntax-',
+		),
+	);
 
 	try {
 		assert.equal(spawnSync('git', ['init', '-q'], { cwd: dir }).status, 0);
 
 		for (const [file, content] of Object.entries(files)) {
-			await writeFile(join(dir, file), content);
+			await writeFile(
+				join(dir, file),
+				content,
+			);
 		}
 
 		assert.equal(spawnSync('git', ['add', '.'], { cwd: dir }).status, 0);
 
 		await fn(dir);
 	} finally {
-		await rm(dir, { recursive: true, force: true });
+		await rm(
+			dir,
+			{ recursive: true, force: true },
+		);
 	}
 }
 
 test('accepts valid TypeScript and Vue script blocks', async () => {
 	await withFixture(
 		{
-			'valid.ts': 'const value = computed(() => source.value.trim().toLowerCase());\n',
-			'Valid.vue': '<script setup lang="ts">\nconst value = 1;\n</script>\n<template>{{ value }}</template>\n',
-		},
+				'valid.ts': 'const value = computed(() => source.value.trim().toLowerCase());\n',
+				'Valid.vue': '<script setup lang="ts">\nconst value = 1;\n</script>\n<template>{{ value }}</template>\n',
+			},
 		async (dir) => {
-			const result = spawnSync(process.execPath, [tsx, script, 'valid.ts', 'Valid.vue'], { cwd: dir, encoding: 'utf8' });
+				const result = spawnSync(process.execPath, [tsx, script, 'valid.ts', 'Valid.vue'], { cwd: dir, encoding: 'utf8' });
 
-			assert.equal(result.status, 0, result.stderr || result.stdout);
-			assert.match(result.stdout, /\[validate-syntax\] checked 2 file\(s\)/);
-		},
+				assert.equal(result.status, 0, result.stderr || result.stdout);
+				assert.match(result.stdout, /\[validate-syntax\] checked 2 file\(s\)/);
+			},
 	);
 });
 
 test('accepts Vue TSX and JSX script blocks', async () => {
 	await withFixture(
 		{
-			'Component.vue': '<script setup lang="tsx">\nconst view = <section>Ready</section>;\n</script>\n',
-			'Legacy.vue': "<script lang='jsx'>\nconst view = <section>Ready</section>;\n</script>\n",
-		},
+				'Component.vue': '<script setup lang="tsx">\nconst view = <section>Ready</section>;\n</script>\n',
+				'Legacy.vue': "<script lang='jsx'>\nconst view = <section>Ready</section>;\n</script>\n",
+			},
 		async (dir) => {
-			const result = spawnSync(process.execPath, [tsx, script, 'Component.vue', 'Legacy.vue'], { cwd: dir, encoding: 'utf8' });
+				const result = spawnSync(process.execPath, [tsx, script, 'Component.vue', 'Legacy.vue'], { cwd: dir, encoding: 'utf8' });
 
-			assert.equal(result.status, 0, result.stderr || result.stdout);
-			assert.match(result.stdout, /\[validate-syntax\] checked 2 file\(s\)/);
-		},
+				assert.equal(result.status, 0, result.stderr || result.stdout);
+				assert.match(result.stdout, /\[validate-syntax\] checked 2 file\(s\)/);
+			},
 	);
 });
 
 test('reports Vue syntax errors on original file lines', async () => {
 	await withFixture(
 		{
-			'Broken.vue': '<template>\n\t<div />\n</template>\n<script setup lang="ts">\nconst broken = ;\n</script>\n',
-		},
+				'Broken.vue': '<template>\n\t<div />\n</template>\n<script setup lang="ts">\nconst broken = ;\n</script>\n',
+			},
 		async (dir) => {
-			const result = spawnSync(process.execPath, [tsx, script, 'Broken.vue'], { cwd: dir, encoding: 'utf8' });
+				const result = spawnSync(process.execPath, [tsx, script, 'Broken.vue'], { cwd: dir, encoding: 'utf8' });
 
-			assert.equal(result.status, 1);
-			assert.match(result.stderr, /\[validate-syntax\].*Broken\.vue/);
-			assert.match(result.stderr, /5 \| const broken = ;/);
-		},
+				assert.equal(result.status, 1);
+				assert.match(result.stderr, /\[validate-syntax\].*Broken\.vue/);
+				assert.match(result.stderr, /5 \| const broken = ;/);
+			},
 	);
 });
 
 test('fails with a clear diagnostic for corrupted formatter output', async () => {
 	await withFixture(
 		{
-			'useAppController.ts': 'const normalizedDebouncedSearch = computed(() => debouncedSearch.value.trim().toLowerCase()););\n',
-		},
+				'useAppController.ts': 'const normalizedDebouncedSearch = computed(() => debouncedSearch.value.trim().toLowerCase()););\n',
+			},
 		async (dir) => {
-			const result = spawnSync(process.execPath, [tsx, script, 'useAppController.ts'], { cwd: dir, encoding: 'utf8' });
+				const result = spawnSync(process.execPath, [tsx, script, 'useAppController.ts'], { cwd: dir, encoding: 'utf8' });
 
-			assert.equal(result.status, 1);
-			assert.match(result.stderr, /\[validate-syntax\].*useAppController\.ts/);
-			assert.match(result.stderr, /Unexpected token/);
-		},
+				assert.equal(result.status, 1);
+				assert.match(result.stderr, /\[validate-syntax\].*useAppController\.ts/);
+				assert.match(result.stderr, /Unexpected token/);
+			},
 	);
 });
 
 test('skips missing paths and ignores non-source arguments', async () => {
 	await withFixture(
 		{
-			'notes.md': '# Notes\n',
-		},
+				'notes.md': '# Notes\n',
+			},
 		async (dir) => {
-			const result = spawnSync(process.execPath, [tsx, script, 'missing.ts', 'notes.md'], { cwd: dir, encoding: 'utf8' });
+				const result = spawnSync(process.execPath, [tsx, script, 'missing.ts', 'notes.md'], { cwd: dir, encoding: 'utf8' });
 
-			assert.equal(result.status, 0, result.stderr || result.stdout);
-			assert.match(result.stderr, /\[validate-syntax\] path not found, skipping: missing\.ts/);
-			assert.match(result.stdout, /\[validate-syntax\] checked 1 file\(s\)/);
-		},
+				assert.equal(result.status, 0, result.stderr || result.stdout);
+				assert.match(result.stderr, /\[validate-syntax\] path not found, skipping: missing\.ts/);
+				assert.match(result.stdout, /\[validate-syntax\] checked 1 file\(s\)/);
+			},
 	);
 });

--- a/packages/devx/vite.config.ts
+++ b/packages/devx/vite.config.ts
@@ -1,3 +1,5 @@
 import { defineConfig } from 'vite-plus';
 
-export default defineConfig({});
+export default defineConfig(
+	{},
+);

--- a/packages/driver/internal/cli/runner_test.go
+++ b/packages/driver/internal/cli/runner_test.go
@@ -2,13 +2,13 @@ package cli
 
 import (
 	"bytes"
-	"github.com/oullin/fmtkit/packages/driver/internal/sourcefiles"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/oullin/fmtkit/packages/driver/internal/sourcefiles"
 	driverreport "github.com/oullin/fmtkit/packages/driver/report"
 	formatterengine "github.com/oullin/fmtkit/packages/formatter/engine"
 	"github.com/oullin/fmtkit/packages/vet"

--- a/packages/driver/internal/sourcefiles/sourcefiles.go
+++ b/packages/driver/internal/sourcefiles/sourcefiles.go
@@ -13,6 +13,15 @@ import (
 // Selection is how much of the working tree a collection covers.
 type Selection int
 
+type Options struct {
+	Cwd                 string
+	IncludeDeclarations bool
+	Scopes              []string
+
+	// Selection defaults to SelectionAll.
+	Selection Selection
+}
+
 const (
 	// SelectionAll covers every non-ignored file: tracked plus untracked.
 	// This is what `format-all` runs against.
@@ -33,15 +42,6 @@ func (s Selection) gitArgs() []string {
 	}
 
 	return []string{"--cached", "--others"}
-}
-
-type Options struct {
-	Cwd                 string
-	IncludeDeclarations bool
-	Scopes              []string
-
-	// Selection defaults to SelectionAll.
-	Selection Selection
 }
 
 // Collect lists the TS/Vue files under the given scopes.

--- a/packages/driver/internal/tsruntime/run.go
+++ b/packages/driver/internal/tsruntime/run.go
@@ -33,7 +33,8 @@ const (
 )
 
 // RunPipeline runs the full TS/Vue formatting pipeline (blank-lines -> oxfmt
-// -> fluent-chains -> oxfmt -> validate-syntax).
+// -> fluent-chains -> validate-syntax). oxfmt is an internal normalising step,
+// not the last word: the project passes run after it and own the final style.
 func (s Support) RunPipeline(opts RunOptions) error {
 	cwd, err := sourcesCwd()
 


### PR DESCRIPTION
Stacked on #52 — review that first.

## The bug

oxfmt ran twice: once to normalise, then **again after the project passes**. That second run collapsed anything fitting in `printWidth: 200` — which is most of what `expanded-calls` and `fluent-chains` had just expanded. The passes ran on every file, every time, and their work was discarded before it reached disk.

`expanded-calls` was **completely inert**. Its own test asserts:

```ts
resolveConfig(prefix, buildOptions(env), { strict: true })
// →
resolveConfig(
	prefix,
	buildOptions(env),
	{ strict: true },
);
```

The pipeline shipped it on one line. `fluent-chains` survived only where a chain already exceeded printWidth. The tests pass because they call the formatters directly and **never run the pipeline**.

## The fix

The pipeline is now `blank-lines → oxfmt → fluent-chains → validate-syntax` — the order the README always described: *"runs oxfmt over your sources, **then** applies project-specific syntax passes."* oxfmt normalises; the project passes then impose the style fmtkit ships.

**Removing the second oxfmt exposed the bug it was hiding.** `expanded-calls` lifted an argument onto its own line without re-indenting the argument's *own* continuation lines, so a multiline object kept its call-site depth:

```
{
...init,        ← kept the shallower depth
```

`rebaseIndent` fixes it, threading the original base indent through the recursion — `formatCall` output is already built at the target indent and must not be rebased again or it double-shifts. Mutation-checked: reverting the rebase fails the new test.

## Checking with bare oxfmt was always the wrong tool

fmtkit's format is the pipeline's output, and the pipeline deliberately diverges from oxfmt. So `oxfmt --check` disagrees with correctly-formatted source *by design*.

- `devx`'s `oxfmt` / `oxfmt:check` scripts are **gone** — they asserted the tree matched a tool that is not the formatter.
- `blank-lines` / `blank-lines:check` are gone too: they ran with **no file arguments** and checked zero files (that's the `processed 0 file(s)` in CI).
- **`check-self-formatted.sh`** runs fmtkit over the repo and fails on any diff. It lives in the `binary` job because `check` has no Go — and only fmtkit can say whether a tree is fmtkit-formatted.

## What it looks like

```ts
-	const entries = await readdir(dir, { recursive: true, withFileTypes: true });
+	const entries = await readdir(
+		dir,
+		{ recursive: true, withFileTypes: true },
+	);
```

Verbose, and it is what the transformers have always been written and tested to do. **17 files, +550/−314** here; **135/237 files, +4510/−2165** in edgekit.

## Verified

- Pipeline is **idempotent** — pass 2 is byte-identical (oxfmt still collapses mid-run and fluent-chains re-expands, so the `N changed` line stays noisy; the output is stable).
- `check-self-formatted.sh` → `repository is fmtkit-formatted`.
- `go test ./...`, 102 devx tests, and the binary smoke test (Vue + typescript/oxc plugin probes) all pass.

## Found on the way — a separate, serious bug (not fixed here)

The new self-check immediately caught fmtkit's **Go** spacing rule destroying comments. `type definitions must appear at the beginning of the file` hoists the type and **strips every doc comment in the file**, including one lifted out of a function body:

```go
// KindA is the first kind.
// Args returns the args for k.
// A meaningful inline note.     ← was inside an if block

// Options carries options.
type Options struct { Name string }
```

The declarations lose their docs entirely. This is on `main` today and unrelated to this PR — it only triggers when a type is not already at the top. I wrote `sourcefiles.go` with the types first by hand to sidestep it. Filed separately; it deserves its own fix.