### PR TITLE
fix: format-all is not single-run idempotent — run blank-lines again after fluent-chains

### DIFF
--- a/packages/go/driver/internal/tsruntime/run.go
+++ b/packages/go/driver/internal/tsruntime/run.go
@@ -33,8 +33,9 @@ const (
 )
 
 // RunPipeline runs the full TS/Vue formatting pipeline (blank-lines -> oxfmt
-// -> fluent-chains -> validate-syntax). oxfmt is an internal normalising step,
-// not the last word: the project passes run after it and own the final style.
+// -> fluent-chains -> blank-lines -> validate-syntax). oxfmt is an internal
+// normalising step, not the last word: the project passes run after it and
+// own the final style.
 func (s Support) RunPipeline(opts RunOptions) error {
 	cwd, err := sourcesCwd()
 

--- a/packages/ts/sidecar/src/format-all.test.ts
+++ b/packages/ts/sidecar/src/format-all.test.ts
@@ -193,6 +193,48 @@ test('format-all pipeline formats files and exits 0 end-to-end', async () => {
 	}
 });
 
+test('format-all pipeline reaches a fixed point in a single run', async () => {
+	const dir = await mkdtemp(
+		join(
+			tmpdir(),
+			'fmtkit-sidecar-format-all-fixpoint-',
+		),
+	);
+
+	try {
+		const file = join(dir, 'app.ts');
+
+		// A single-line statement followed by a call that expanded-calls turns
+		// multiline: the blank line separating them can only be inserted after
+		// the expansion has happened.
+		await writeFile(
+			file,
+			"function queueMessage(id: string, body: object) {\n\treturn { id, body };\n}\n\nexport function run() {\n\tconst registry = new Map<string, string>();\n\tconst invalid = queueMessage('1', { unexpected: true });\n\treturn [registry, invalid];\n}\n",
+		);
+
+		await execFileAsync(
+			tsxBin,
+			[formatAllScript, '--format-files', file, '--syntax-files', file],
+		);
+
+		const afterFirstRun = await readFile(file, 'utf8');
+
+		assert.match(afterFirstRun, /queueMessage\(\n\t\t'1',/, 'expected the call to be expanded');
+
+		await execFileAsync(
+			tsxBin,
+			[formatAllScript, '--format-files', file, '--syntax-files', file],
+		);
+
+		assert.equal(await readFile(file, 'utf8'), afterFirstRun, 'second run must not change an already formatted file');
+	} finally {
+		await rm(
+			dir,
+			{ recursive: true, force: true },
+		);
+	}
+});
+
 test('format-all pipeline deduplicates repeated input paths', async () => {
 	const dir = await mkdtemp(
 		join(

--- a/packages/ts/sidecar/src/format-all.ts
+++ b/packages/ts/sidecar/src/format-all.ts
@@ -7,9 +7,9 @@ import { isNotFoundError, isTargetFile } from '#sidecar/pass-utils';
 import { validateFile } from '#sidecar/validate-syntax';
 
 // format-all runs the full TS pipeline (blank-lines → oxfmt → fluent-chains →
-// validate-syntax) inside a single process. Files within a pass are processed
-// concurrently; results are reported in input order so the output stays
-// deterministic.
+// blank-lines → validate-syntax) inside a single process. Files within a pass
+// are processed concurrently; results are reported in input order so the
+// output stays deterministic.
 //
 // oxfmt runs *before* the project passes, never after. It is an internal step
 // that normalises the file; the project passes then impose the style fmtkit
@@ -221,6 +221,13 @@ export async function main(): Promise<void> {
 	await runOxfmt(pipelineOptions);
 
 	await runPass('fluent-chains', formatTargets, options.check, processFluentChainsFile);
+
+	// fluent-chains (and the expanded-calls pass it applies) turns single-line
+	// statements multiline, creating blank-line obligations the first pass
+	// could not see. Without this second pass the pipeline only converges on
+	// its next invocation, so a format-then-diff gate rejects freshly
+	// formatted code.
+	await runPass('blank-lines', formatTargets, options.check, processBlankLinesFile);
 
 	await runValidate(syntaxTargets);
 }


### PR DESCRIPTION
## Problem

`format-all` needs **two runs** to reach stable output. The pipeline order is blank-lines → oxfmt → fluent-chains (which also applies expanded-calls). When expanded-calls turns a single-line statement multiline, the blank-line obligations that creates are only visible to the *next* invocation — the blank-lines pass already ran.

Reproduced against edgekit @ `d03c492` (formatted under v0.5.3): the v0.5.5 binary needed a second `fmtkit format-all --ts` run before the diff stabilised, with 7 files picking up blank-line insertions on run two. Consequence: a developer formats once, commits, and a format-then-diff CI gate (like edgekit's `make format`) rejects the freshly formatted code.

Minimal reproduction — one run of the pipeline leaves this file unstable:

```ts
export function run() {
	const registry = new Map<string, string>();
	const invalid = queueMessage('1', { unexpected: true });
	return [registry, invalid];
}
```

Run 1 expands the `queueMessage` call; run 2 inserts the blank line between `registry` and the now-multiline `invalid`.

## Fix

Run the blank-lines pass a second time after fluent-chains, so blank-line style is applied to the statements the expansion passes just made multiline. blank-lines only inserts/removes blank lines — it cannot create new expansion work — so the pipeline reaches its fixed point in a single run.

No contract change: the one-run output is byte-identical to what two runs of the current pipeline produce (verified against edgekit's converged tree). The Go summarizer already picks the last `[blank-lines] processed` line, so the CLI summary needs no changes.

## Testing

- New end-to-end regression test: formats the fixture above, asserts the call was expanded, runs the pipeline again, and asserts the second run is a no-op. Fails on `main`, passes with the fix.
- Full sidecar suite: 103/103 pass; `tsc --noEmit` clean; `go test ./...` all packages pass.
- Real-world check: edgekit's `tests/queue-dispatch.test.ts` (a two-run file under v0.5.5) now converges in one run, byte-identical to its committed fixed point.