### PR TITLE
fix(ts): detect the indent unit instead of hardcoding tabs in sidecar passes

### DIFF
--- a/packages/ts/sidecar/src/body-wrapper.test.ts
+++ b/packages/ts/sidecar/src/body-wrapper.test.ts
@@ -53,6 +53,15 @@ test('wraps the loop body while keeping its comment', () => {
 	assert.match(result, /\/\/ spin/);
 });
 
+test('wraps with four spaces when the source is space-indented', () => {
+	const source = ['function run() {', '    if (ready) go();', '}', ''].join('\n');
+	const expected = ['function run() {', '    if (ready) {', '        go();', '    }', '}', ''].join('\n');
+	const result = wrapFully(source);
+
+	assert.equal(result, expected);
+	assert.ok(!result.includes('\t'), 'space-indented body wrap must not introduce tabs');
+});
+
 test('leaves already-braced bodies alone', () => {
 	const source = 'if (ready) {\n\trun();\n}\n';
 

--- a/packages/ts/sidecar/src/body-wrapper.ts
+++ b/packages/ts/sidecar/src/body-wrapper.ts
@@ -16,7 +16,7 @@ const STATEMENT_BODY_KEYS: Record<string, string[]> = {
 
 /** Wraps unbraced statement bodies without changing unparsable source. */
 export class BodyWrapper {
-	static #wrapStatementBody(source: string, owner: Node, body: Node): Edit | null {
+	static #wrapStatementBody(source: string, owner: Node, body: Node, indentUnit: string): Edit | null {
 		if (body.type === 'BlockStatement') {
 			return null;
 		}
@@ -39,7 +39,7 @@ export class BodyWrapper {
 		return {
 			start,
 			end,
-			replacement: `{\n${indent}\t${bodySource}\n${indent}}`,
+			replacement: `{\n${indent}${indentUnit}${bodySource}\n${indent}}`,
 		};
 	}
 
@@ -58,6 +58,7 @@ export class BodyWrapper {
 		}
 
 		const edits: Edit[] = [];
+		const indentUnit = SourceText.detectIndentUnit(content);
 
 		Ast.visit(parsed.value.program, (node) => {
 			const bodyKeys = STATEMENT_BODY_KEYS[node.type];
@@ -73,7 +74,7 @@ export class BodyWrapper {
 					continue;
 				}
 
-				const edit = BodyWrapper.#wrapStatementBody(content, node, body);
+				const edit = BodyWrapper.#wrapStatementBody(content, node, body, indentUnit);
 
 				if (edit) {
 					edits.push(edit);

--- a/packages/ts/sidecar/src/drizzle-queries.test.ts
+++ b/packages/ts/sidecar/src/drizzle-queries.test.ts
@@ -191,6 +191,30 @@ describe('Drizzle query formatter', () => {
 		assert.equal(FluentChains.format(FluentChains.format(input, 'fixture.ts'), 'fixture.ts'), input);
 	});
 
+	it('nests with four spaces when the source is space-indented', () => {
+		const input = ["import { and, eq } from 'drizzle-orm';", 'function load() {', '    const rows = db.select().from(users).where(and(eq(users.id, id), eq(users.active, true)));', '}', ''].join(
+			'\n',
+		);
+
+		const expected = [
+			"import { and, eq } from 'drizzle-orm';",
+			'function load() {',
+			'    const rows = db.select().from(users).where(',
+			'        and(',
+			'            eq(users.id, id),',
+			'            eq(users.active, true),',
+			'        ),',
+			'    );',
+			'}',
+			'',
+		].join('\n');
+
+		const output = DrizzleQueries.format(input, 'fixture.ts');
+
+		assert.equal(output, expected);
+		assert.ok(!output.includes('\t'), 'space-indented Drizzle formatting must not introduce tabs');
+	});
+
 	it('does not process declaration files', () => {
 		const input = [
 			"import { and, eq } from 'drizzle-orm';",

--- a/packages/ts/sidecar/src/drizzle-queries.ts
+++ b/packages/ts/sidecar/src/drizzle-queries.ts
@@ -435,7 +435,7 @@ export class DrizzleQueries {
 
 	// Emission: render recognised structures and produce non-overlapping edits.
 
-	static #formatArrayExpression(source: string, node: Node, imports: DrizzleImports, comments: readonly Node[], indent: string): string {
+	static #formatArrayExpression(source: string, node: Node, imports: DrizzleImports, comments: readonly Node[], indent: string, indentUnit: string): string {
 		if (SourceText.hasCommentBetween(comments, Ast.getStart(node), Ast.getEnd(node))) {
 			return SourceText.sourceOf(source, node);
 		}
@@ -446,16 +446,16 @@ export class DrizzleQueries {
 			return '[]';
 		}
 
-		const nextIndent = `${indent}\t`;
+		const nextIndent = `${indent}${indentUnit}`;
 
 		const formatted = elements.map((element) => {
-			return element instanceof Node ? DrizzleQueries.#formatNode(source, element, imports, comments, nextIndent) : '';
+			return element instanceof Node ? DrizzleQueries.#formatNode(source, element, imports, comments, nextIndent, indentUnit) : '';
 		});
 
 		return `[\n${nextIndent}${formatted.join(`,\n${nextIndent}`)},\n${indent}]`;
 	}
 
-	static #formatObjectExpression(source: string, node: Node, imports: DrizzleImports, comments: readonly Node[], indent: string): string {
+	static #formatObjectExpression(source: string, node: Node, imports: DrizzleImports, comments: readonly Node[], indent: string, indentUnit: string): string {
 		if (SourceText.hasCommentBetween(comments, Ast.getStart(node), Ast.getEnd(node))) {
 			return SourceText.sourceOf(source, node);
 		}
@@ -466,7 +466,7 @@ export class DrizzleQueries {
 			return '{}';
 		}
 
-		const nextIndent = `${indent}\t`;
+		const nextIndent = `${indent}${indentUnit}`;
 
 		const formatted = properties.map((property) => {
 			if (property.type !== 'Property') {
@@ -484,13 +484,13 @@ export class DrizzleQueries {
 				return SourceText.sourceOf(source, property);
 			}
 
-			return `${SourceText.sourceOf(source, key)}: ${DrizzleQueries.#formatNode(source, value, imports, comments, nextIndent)}`;
+			return `${SourceText.sourceOf(source, key)}: ${DrizzleQueries.#formatNode(source, value, imports, comments, nextIndent, indentUnit)}`;
 		});
 
 		return `{\n${nextIndent}${formatted.join(`,\n${nextIndent}`)},\n${indent}}`;
 	}
 
-	static #formatHelperCall(source: string, call: Node, imports: DrizzleImports, comments: readonly Node[], indent: string): string {
+	static #formatHelperCall(source: string, call: Node, imports: DrizzleImports, comments: readonly Node[], indent: string, indentUnit: string): string {
 		if (SourceText.hasCommentBetween(comments, Ast.getStart(call), Ast.getEnd(call))) {
 			return SourceText.sourceOf(source, call);
 		}
@@ -503,13 +503,13 @@ export class DrizzleQueries {
 			return SourceText.sourceOf(source, call);
 		}
 
-		const nextIndent = `${indent}\t`;
-		const formatted = args.map((arg) => DrizzleQueries.#formatNode(source, arg, imports, comments, nextIndent));
+		const nextIndent = `${indent}${indentUnit}`;
+		const formatted = args.map((arg) => DrizzleQueries.#formatNode(source, arg, imports, comments, nextIndent, indentUnit));
 
 		return `${DrizzleQueries.#callDisplayName(source, call, imports)}(\n${nextIndent}${formatted.join(`,\n${nextIndent}`)},\n${indent})`;
 	}
 
-	static #formatSetOperationCall(source: string, call: Node, imports: DrizzleImports, comments: readonly Node[], indent: string): string {
+	static #formatSetOperationCall(source: string, call: Node, imports: DrizzleImports, comments: readonly Node[], indent: string, indentUnit: string): string {
 		if (SourceText.hasCommentBetween(comments, Ast.getStart(call), Ast.getEnd(call))) {
 			return SourceText.sourceOf(source, call);
 		}
@@ -520,35 +520,35 @@ export class DrizzleQueries {
 			return SourceText.sourceOf(source, call);
 		}
 
-		const nextIndent = `${indent}\t`;
-		const formatted = args.map((arg) => DrizzleQueries.#formatNode(source, arg, imports, comments, nextIndent));
+		const nextIndent = `${indent}${indentUnit}`;
+		const formatted = args.map((arg) => DrizzleQueries.#formatNode(source, arg, imports, comments, nextIndent, indentUnit));
 
 		return `${DrizzleQueries.#callDisplayName(source, call, imports)}(\n${nextIndent}${formatted.join(`,\n${nextIndent}`)},\n${indent})`;
 	}
 
-	static #formatNode(source: string, node: Node, imports: DrizzleImports, comments: readonly Node[], indent: string): string {
+	static #formatNode(source: string, node: Node, imports: DrizzleImports, comments: readonly Node[], indent: string, indentUnit: string): string {
 		if (node.type === 'ObjectExpression' && DrizzleQueries.#shouldFormatObjectExpression(node)) {
-			return DrizzleQueries.#formatObjectExpression(source, node, imports, comments, indent);
+			return DrizzleQueries.#formatObjectExpression(source, node, imports, comments, indent, indentUnit);
 		}
 
 		if (node.type === 'ArrayExpression' && DrizzleQueries.#shouldFormatArrayExpression(node)) {
-			return DrizzleQueries.#formatArrayExpression(source, node, imports, comments, indent);
+			return DrizzleQueries.#formatArrayExpression(source, node, imports, comments, indent, indentUnit);
 		}
 
 		if (node.type === 'CallExpression') {
 			if (DrizzleQueries.#isSetOperationCall(node, imports)) {
-				return DrizzleQueries.#formatSetOperationCall(source, node, imports, comments, indent);
+				return DrizzleQueries.#formatSetOperationCall(source, node, imports, comments, indent, indentUnit);
 			}
 
 			if (DrizzleQueries.#isImportedHelperCall(node, imports)) {
-				return DrizzleQueries.#formatHelperCall(source, node, imports, comments, indent);
+				return DrizzleQueries.#formatHelperCall(source, node, imports, comments, indent, indentUnit);
 			}
 		}
 
 		return SourceText.sourceOf(source, node);
 	}
 
-	static #formatCallArguments(source: string, call: Node, imports: DrizzleImports, comments: readonly Node[]): Edit | null {
+	static #formatCallArguments(source: string, call: Node, imports: DrizzleImports, comments: readonly Node[], indentUnit: string): Edit | null {
 		const parens = DrizzleQueries.#callParens(source, call);
 		const args = Ast.childNodes(call, 'arguments');
 
@@ -565,8 +565,8 @@ export class DrizzleQueries {
 		const property = callee ? Ast.childNode(callee, 'property') : undefined;
 		const indentPos = callee?.type === 'MemberExpression' && property ? Ast.getStart(property) : Ast.getStart(call);
 		const indent = SourceText.lineIndent(source, indentPos);
-		const argIndent = `${indent}\t`;
-		const formatted = args.map((arg) => DrizzleQueries.#formatNode(source, arg, imports, comments, argIndent));
+		const argIndent = `${indent}${indentUnit}`;
+		const formatted = args.map((arg) => DrizzleQueries.#formatNode(source, arg, imports, comments, argIndent, indentUnit));
 		const replacement = `(\n${argIndent}${formatted.join(`,\n${argIndent}`)},\n${indent})`;
 
 		if (source.slice(parens.open, parens.close + 1) === replacement) {
@@ -606,6 +606,7 @@ export class DrizzleQueries {
 		}
 
 		const edits: Edit[] = [];
+		const indentUnit = SourceText.detectIndentUnit(content);
 
 		Ast.visit(parsed.value.program, (node) => {
 			if (node.type !== 'CallExpression') {
@@ -623,7 +624,7 @@ export class DrizzleQueries {
 					return;
 				}
 
-				const edit = DrizzleQueries.#formatCallArguments(content, node, imports, comments);
+				const edit = DrizzleQueries.#formatCallArguments(content, node, imports, comments, indentUnit);
 
 				if (edit) {
 					edits.push(edit);

--- a/packages/ts/sidecar/src/expanded-calls.test.ts
+++ b/packages/ts/sidecar/src/expanded-calls.test.ts
@@ -65,6 +65,24 @@ describe('expanded call formatter', () => {
 		assert.equal(ExpandedCalls.format(input, 'types.d.ts'), input);
 	});
 
+	it('nests with four spaces when the source is space-indented', () => {
+		const input = ['function run() {', '    return outer(inner(deep(a, b)), tail);', '}', ''].join('\n');
+		const expected = ['function run() {', '    return outer(', '        inner(', '            deep(a, b),', '        ),', '        tail,', '    );', '}', ''].join('\n');
+		const once = ExpandedCalls.format(input, 'fixture.ts');
+
+		assert.equal(once, expected);
+		assert.equal(ExpandedCalls.format(once, 'fixture.ts'), expected);
+		assert.ok(!once.includes('\t'), 'expanded output must not introduce tabs into a space-indented file');
+	});
+
+	it('nests a space-indented top-level call one level deep with spaces', () => {
+		const input = ['export default defineConfig({', '    cacheDir: "../../storage/.cache",', '    test: { globals: true },', '});', ''].join('\n');
+		const output = ExpandedCalls.format(input, 'fixture.ts');
+
+		assert.ok(!output.includes('\t'), 'space-indented expansion must not introduce tabs');
+		assert.match(output, /defineConfig\(\n {4}\{/);
+	});
+
 	it('re-indents a multiline object argument to its new depth', () => {
 		// The object's inner lines were written against the statement's indent.
 		// Expanding pushes the object one level deeper, so they have to move with

--- a/packages/ts/sidecar/src/expanded-calls.ts
+++ b/packages/ts/sidecar/src/expanded-calls.ts
@@ -145,7 +145,7 @@ export class ExpandedCalls {
 			.join('\n');
 	}
 
-	static #formatCallParens(source: string, call: Node, comments: readonly Node[], indent: string, baseIndent: string): string | null {
+	static #formatCallParens(source: string, call: Node, comments: readonly Node[], indent: string, baseIndent: string, indentUnit: string): string | null {
 		const parens = ExpandedCalls.#calleeParens(source, call);
 		const args = ExpandedCalls.#callArguments(call);
 
@@ -157,10 +157,10 @@ export class ExpandedCalls {
 			return null;
 		}
 
-		const argIndent = `${indent}\t`;
+		const argIndent = `${indent}${indentUnit}`;
 
 		const formattedArgs = args.map((arg) => {
-			return ExpandedCalls.#formatNode(source, arg, comments, argIndent, baseIndent);
+			return ExpandedCalls.#formatNode(source, arg, comments, argIndent, baseIndent, indentUnit);
 		});
 
 		const separator = `,\n${argIndent}`;
@@ -169,9 +169,9 @@ export class ExpandedCalls {
 		return `(\n${argIndent}${formattedArgs.join(separator)}${trailingComma}\n${indent})`;
 	}
 
-	static #formatCall(source: string, call: Node, comments: readonly Node[], indent: string, baseIndent: string): string {
+	static #formatCall(source: string, call: Node, comments: readonly Node[], indent: string, baseIndent: string, indentUnit: string): string {
 		const parens = ExpandedCalls.#calleeParens(source, call);
-		const formattedParens = ExpandedCalls.#formatCallParens(source, call, comments, indent, baseIndent);
+		const formattedParens = ExpandedCalls.#formatCallParens(source, call, comments, indent, baseIndent, indentUnit);
 
 		if (!parens || formattedParens === null) {
 			return ExpandedCalls.#rebaseIndent(SourceText.sourceOf(source, call), baseIndent, indent);
@@ -183,7 +183,7 @@ export class ExpandedCalls {
 	// indent is where node will sit once expanded; baseIndent is where its source
 	// text came from and is threaded down unchanged, because nothing has moved in
 	// the source yet however deep the recursion goes.
-	static #formatNode(source: string, node: Node, comments: readonly Node[], indent: string, baseIndent: string): string {
+	static #formatNode(source: string, node: Node, comments: readonly Node[], indent: string, baseIndent: string, indentUnit: string): string {
 		if (node.type !== 'CallExpression') {
 			return ExpandedCalls.#rebaseIndent(SourceText.sourceOf(source, node), baseIndent, indent);
 		}
@@ -192,7 +192,7 @@ export class ExpandedCalls {
 			return ExpandedCalls.#rebaseIndent(SourceText.sourceOf(source, node), baseIndent, indent);
 		}
 
-		return ExpandedCalls.#formatCall(source, node, comments, indent, baseIndent);
+		return ExpandedCalls.#formatCall(source, node, comments, indent, baseIndent, indentUnit);
 	}
 	/**
 	 * Compute edits for calls whose arguments require a multiline layout.
@@ -215,6 +215,7 @@ export class ExpandedCalls {
 		const comments = parsed.value.comments;
 		const parents = new WeakMap<Node, Node>();
 		const edits: Edit[] = [];
+		const indentUnit = SourceText.detectIndentUnit(content);
 
 		ExpandedCalls.#collectParents(parsed.value.program, parents);
 
@@ -239,7 +240,7 @@ export class ExpandedCalls {
 
 			const indent = SourceText.lineIndent(content, Ast.getStart(node));
 
-			const replacement = ExpandedCalls.#formatCallParens(content, node, comments, indent, indent);
+			const replacement = ExpandedCalls.#formatCallParens(content, node, comments, indent, indent, indentUnit);
 			const current = content.slice(parens.open, parens.close + 1);
 
 			if (replacement === null || replacement === current) {

--- a/packages/ts/sidecar/src/fluent-chains.test.ts
+++ b/packages/ts/sidecar/src/fluent-chains.test.ts
@@ -81,6 +81,15 @@ describe('fluent chain formatter', () => {
 		assert.equal(FluentChains.format(input, 'fixture.ts'), expected);
 	});
 
+	it('splits chains with four spaces when the source is space-indented', () => {
+		const input = ['function routes() {', "    return createRouter().use('*', bindEnv).get('/', getMe);", '}', ''].join('\n');
+		const expected = ['function routes() {', '    return createRouter()', "        .use('*', bindEnv)", "        .get('/', getMe);", '}', ''].join('\n');
+		const output = FluentChains.format(input, 'fixture.ts');
+
+		assert.equal(output, expected);
+		assert.ok(!output.includes('\t'), 'space-indented chain splitting must not introduce tabs');
+	});
+
 	it('leaves short value transform chains unchanged', () => {
 		const input = ['const normalized = value.trim().toLowerCase();', ''].join('\n');
 

--- a/packages/ts/sidecar/src/fluent-chains.ts
+++ b/packages/ts/sidecar/src/fluent-chains.ts
@@ -27,12 +27,6 @@ type FluentChain = {
 
 /** Formats fluent chains and the structured calls composed with them. */
 export class FluentChains {
-	static #detectIndent(content: string): string {
-		const match = content.match(/^[ \t]+(?!\*)(?=\S)/m);
-
-		return match?.[0] ?? '\t';
-	}
-
 	static #memberCallLink(source: string, member: Node, object: Node, comments: readonly Node[]): ChainLink | null {
 		if (member.computed) {
 			return null;
@@ -127,7 +121,7 @@ export class FluentChains {
 
 		const comments = parsed.value.comments;
 		const edits = new Map<string, Edit>();
-		const indentStep = FluentChains.#detectIndent(content);
+		const indentStep = SourceText.detectIndentUnit(content);
 
 		Ast.visit(parsed.value.program, (node) => {
 			if (node.type !== 'CallExpression') {

--- a/packages/ts/sidecar/src/source-text.test.ts
+++ b/packages/ts/sidecar/src/source-text.test.ts
@@ -9,3 +9,29 @@ test('SourceText.lineIndent returns the leading whitespace of the position line'
 
 	assert.equal(SourceText.lineIndent(source, 0), '');
 });
+
+test('SourceText.detectIndentUnit reads the unit from the first indented line', () => {
+	const spaces = 'function run() {\n    return go();\n}\n';
+
+	assert.equal(SourceText.detectIndentUnit(spaces), '    ');
+
+	const tabs = 'function run() {\n\treturn go();\n}\n';
+
+	assert.equal(SourceText.detectIndentUnit(tabs), '\t');
+
+	const twoSpaces = 'const value = {\n  key: 1,\n};\n';
+
+	assert.equal(SourceText.detectIndentUnit(twoSpaces), '  ');
+});
+
+test('SourceText.detectIndentUnit falls back to a tab for un-indented source', () => {
+	assert.equal(SourceText.detectIndentUnit('const value = 1;\n'), '\t');
+
+	assert.equal(SourceText.detectIndentUnit(''), '\t');
+});
+
+test('SourceText.detectIndentUnit skips block-comment continuation lines', () => {
+	const source = ['/**', ' * Doc comment.', ' */', 'function run() {', '    return go();', '}', ''].join('\n');
+
+	assert.equal(SourceText.detectIndentUnit(source), '    ');
+});

--- a/packages/ts/sidecar/src/source-text.ts
+++ b/packages/ts/sidecar/src/source-text.ts
@@ -38,6 +38,23 @@ export class SourceText {
 	}
 
 	/**
+	 * Infer the file's per-level indentation unit from its content.
+	 *
+	 * The unit is read from the leading whitespace of the first indented,
+	 * non-comment line so that inserted nesting matches the surrounding style
+	 * (spaces or tabs) instead of a hardcoded tab. Files with no indented line
+	 * yet fall back to a tab.
+	 *
+	 * @param content - The source text being formatted.
+	 * @returns The detected indent unit, or a tab when none can be inferred.
+	 */
+	static detectIndentUnit(content: string): string {
+		const match = content.match(/^[ \t]+(?!\*)(?=\S)/m);
+
+		return match?.[0] ?? '\t';
+	}
+
+	/**
 	 * Slice the source range occupied by an AST node.
 	 *
 	 * @param source - The complete source text.


### PR DESCRIPTION
## Problem

The TS sidecar's wrap/expand passes hardcode a literal tab (`\t`) as the per-level nesting unit. The pipeline runs oxfmt *before* these passes (blank-lines → oxfmt → fluent-chains/drizzle/expanded-calls → …), so in a project whose `.oxfmtrc.json` sets `useTabs: false` the passes wrap tab prefixes around oxfmt's space-indented interiors and nothing re-normalizes them afterward — the final output has mixed indentation:

```ts
export default defineConfig(
\t{
\t    cacheDir: "../../storage/.cache/vitest/store",
```

Invisible in this repo (`useTabs: true`); reproduced downstream in `gocanto-sh` (4-space indent).

## Fix

- `source-text.ts` — new shared `SourceText.detectIndentUnit(content)`, lifting the regex `FluentChains` already used (`/^[ \t]+(?!\*)(?=\S)/m`, `"\t"` fallback).
- `fluent-chains.ts` — drops its private `#detectIndent` in favor of the shared helper.
- `expanded-calls.ts` — detects the unit once in `computeEdits` and threads `indentUnit` through `#formatCallParens` → `#formatCall` → `#formatNode`, so every recursion level appends the file's own unit.
- `drizzle-queries.ts` — same threading through `#formatCallArguments`, `#formatNode`, `#formatArrayExpression`, `#formatObjectExpression`, `#formatHelperCall`, `#formatSetOperationCall`.
- `body-wrapper.ts` — detects the unit in `computeEdits`, passes it into `#wrapStatementBody`.

Tab-indented sources are unaffected: detection returns `"\t"` for them, and every pre-existing fixture passes unchanged.

## Tests

- New space-indented cases per pass proving 4-space sources get 4-space nesting (no tabs), plus unit tests for `detectIndentUnit` (spaces/tabs/2-space, empty and un-indented fallback, block-comment skip).
- `pnpm test`: 123 pass / 0 fail (was 115). `pnpm typecheck`: clean. `make format` over the changed sources: clean.

## Note for review

`detectIndentUnit` takes the entire leading whitespace of the first indented non-comment line as the unit — the pre-existing FluentChains contract, preserved verbatim. A file whose first indented line sits deeper than one level would infer a larger unit; conventionally formatted files are unaffected.