### PR TITLE
fix(ts): stop re-indenting template literals in the expanded-call pass

### DIFF
--- a/packages/ts/sidecar/package.json
+++ b/packages/ts/sidecar/package.json
@@ -50,6 +50,8 @@
 		"#sidecar/source-text.js": "./src/source-text.ts",
 		"#sidecar/sources": "./src/sources.ts",
 		"#sidecar/sources.js": "./src/sources.ts",
+		"#sidecar/template-spans": "./src/template-spans.ts",
+		"#sidecar/template-spans.js": "./src/template-spans.ts",
 		"#sidecar/types": "./src/types.ts",
 		"#sidecar/vue-script": "./src/vue-script.ts",
 		"#sidecar/vue-script.js": "./src/vue-script.ts",

--- a/packages/ts/sidecar/src/blank-lines.test.ts
+++ b/packages/ts/sidecar/src/blank-lines.test.ts
@@ -63,178 +63,236 @@ async function withFixture(files: Record<string, string>, fn: (dir: string) => P
 test('adds expected blank lines in Vue script blocks', async () => {
 	await withFixture(
 		{
-				'AgentDock.vue': [
-					'<script setup lang="ts">',
-					'const hoveredItem = computed(() => {',
-					'    const id = hoveredId.value;',
-					'    if (!id) return null;',
-					'    if (id in systemLabels) return { id, label: systemLabels[id], shortcut: undefined };',
-					'    return props.items.find((i) => i.id === id) ?? null;',
-					'});',
-					'</script>',
-					'',
-				].join('\n'),
-			},
+			'AgentDock.vue': [
+				'<script setup lang="ts">',
+				'const hoveredItem = computed(() => {',
+				'    const id = hoveredId.value;',
+				'    if (!id) return null;',
+				'    if (id in systemLabels) return { id, label: systemLabels[id], shortcut: undefined };',
+				'    return props.items.find((i) => i.id === id) ?? null;',
+				'});',
+				'</script>',
+				'',
+			].join('\n'),
+		},
 		async (dir) => {
-				run(process.execPath, ['--import', tsx, script, 'AgentDock.vue'], dir);
+			run(
+				process.execPath,
+				['--import', tsx, script, 'AgentDock.vue'],
+				dir,
+			);
 
-				const output = await readFile(join(dir, 'AgentDock.vue'), 'utf8');
+			const output = await readFile(
+				join(dir, 'AgentDock.vue'),
+				'utf8',
+			);
 
-				assert.match(output, /const hoveredItem = computed\(\(\) => \{\n    const id = hoveredId\.value;\n\n    if \(!id\) \{/);
-				assert.match(output, /return null;\n    \}\n\n    if \(id in systemLabels\) \{/);
-				assert.match(output, /shortcut: undefined \};\n    \}\n\n    return props\.items/);
-			},
+			assert.match(output, /const hoveredItem = computed\(\(\) => \{\n    const id = hoveredId\.value;\n\n    if \(!id\) \{/);
+			assert.match(output, /return null;\n    \}\n\n    if \(id in systemLabels\) \{/);
+			assert.match(output, /shortcut: undefined \};\n    \}\n\n    return props\.items/);
+		},
 	);
 });
 
 test('keeps adjacent computed declarations syntactically valid', async () => {
 	await withFixture(
 		{
-				'useAppController.ts': [
-					'import { computed, ref } from "vue";',
-					'',
-					'export function useAppController() {',
-					'\tconst searchQuery = ref("");',
-					'\tconst debouncedSearch = ref("");',
-					'\tconst normalizedSearch = computed(() => searchQuery.value.trim().toLowerCase());',
-					'\tconst normalizedDebouncedSearch = computed(() => debouncedSearch.value.trim().toLowerCase());',
-					'',
-					'\treturn { normalizedSearch, normalizedDebouncedSearch };',
-					'}',
-					'',
-				].join('\n'),
-			},
+			'useAppController.ts': [
+				'import { computed, ref } from "vue";',
+				'',
+				'export function useAppController() {',
+				'\tconst searchQuery = ref("");',
+				'\tconst debouncedSearch = ref("");',
+				'\tconst normalizedSearch = computed(() => searchQuery.value.trim().toLowerCase());',
+				'\tconst normalizedDebouncedSearch = computed(() => debouncedSearch.value.trim().toLowerCase());',
+				'',
+				'\treturn { normalizedSearch, normalizedDebouncedSearch };',
+				'}',
+				'',
+			].join('\n'),
+		},
 		async (dir) => {
-				run(process.execPath, ['--import', tsx, script, 'useAppController.ts'], dir);
-				run(process.execPath, ['--import', tsx, script, 'useAppController.ts'], dir);
+			run(
+				process.execPath,
+				['--import', tsx, script, 'useAppController.ts'],
+				dir,
+			);
+			run(
+				process.execPath,
+				['--import', tsx, script, 'useAppController.ts'],
+				dir,
+			);
 
-				const output = await readFile(join(dir, 'useAppController.ts'), 'utf8');
+			const output = await readFile(
+				join(dir, 'useAppController.ts'),
+				'utf8',
+			);
 
-				assert.doesNotMatch(output, /\);\);/);
-				assert.match(output, /const normalizedDebouncedSearch = computed\(\(\) => debouncedSearch\.value\.trim\(\)\.toLowerCase\(\)\);/);
-			},
+			assert.doesNotMatch(output, /\);\);/);
+			assert.match(output, /const normalizedDebouncedSearch = computed\(\(\) => debouncedSearch\.value\.trim\(\)\.toLowerCase\(\)\);/);
+		},
 	);
 });
 
 test('ignores untracked ignored files and declaration files', async () => {
 	await withFixture(
 		{
-				'.gitignore': 'ignored.ts\n',
-				'tracked.ts': ['function run() {', '\tconst value = 1;', '\tif (value) return value;', '\treturn 0;', '}', ''].join('\n'),
-				'ignored.ts': ['function run() {', '\tconst value = 1;', '\tif (value) return value;', '}', ''].join('\n'),
-				'types.d.ts': ['declare const value: string;', 'declare function run(): string;', ''].join('\n'),
-			},
+			'.gitignore': 'ignored.ts\n',
+			'tracked.ts': ['function run() {', '\tconst value = 1;', '\tif (value) return value;', '\treturn 0;', '}', ''].join('\n'),
+			'ignored.ts': ['function run() {', '\tconst value = 1;', '\tif (value) return value;', '}', ''].join('\n'),
+			'types.d.ts': ['declare const value: string;', 'declare function run(): string;', ''].join('\n'),
+		},
 		async (dir) => {
-				run(process.execPath, ['--import', tsx, script, 'tracked.ts', 'types.d.ts'], dir);
+			run(
+				process.execPath,
+				['--import', tsx, script, 'tracked.ts', 'types.d.ts'],
+				dir,
+			);
 
-				const tracked = await readFile(join(dir, 'tracked.ts'), 'utf8');
+			const tracked = await readFile(
+				join(dir, 'tracked.ts'),
+				'utf8',
+			);
 
-				const ignored = await readFile(join(dir, 'ignored.ts'), 'utf8');
+			const ignored = await readFile(
+				join(dir, 'ignored.ts'),
+				'utf8',
+			);
 
-				const types = await readFile(join(dir, 'types.d.ts'), 'utf8');
+			const types = await readFile(
+				join(dir, 'types.d.ts'),
+				'utf8',
+			);
 
-				assert.match(tracked, /const value = 1;\n\n\tif \(value\) \{\n\t\treturn value;\n\t\}\n\n\treturn 0;/);
-				assert.doesNotMatch(ignored, /const value = 1;\n\n\tif/);
-				assert.doesNotMatch(types, /value: string;\n\ndeclare function/);
-			},
+			assert.match(tracked, /const value = 1;\n\n\tif \(value\) \{\n\t\treturn value;\n\t\}\n\n\treturn 0;/);
+			assert.doesNotMatch(ignored, /const value = 1;\n\n\tif/);
+			assert.doesNotMatch(types, /value: string;\n\ndeclare function/);
+		},
 	);
 });
 
 test('skips tracked files missing from the working tree', async () => {
 	await withFixture(
 		{
-				'deleted.ts': ['function run() {', '\tconst value = 1;', '\treturn value;', '}', ''].join('\n'),
-				'kept.ts': ['function run() {', '\tconst value = 1;', '\treturn value;', '}', ''].join('\n'),
-			},
+			'deleted.ts': ['function run() {', '\tconst value = 1;', '\treturn value;', '}', ''].join('\n'),
+			'kept.ts': ['function run() {', '\tconst value = 1;', '\treturn value;', '}', ''].join('\n'),
+		},
 		async (dir) => {
-				await unlink(join(dir, 'deleted.ts'));
+			await unlink(
+				join(dir, 'deleted.ts'),
+			);
 
-				run(process.execPath, ['--import', tsx, script, 'deleted.ts', 'kept.ts'], dir);
+			run(
+				process.execPath,
+				['--import', tsx, script, 'deleted.ts', 'kept.ts'],
+				dir,
+			);
 
-				const kept = await readFile(join(dir, 'kept.ts'), 'utf8');
+			const kept = await readFile(
+				join(dir, 'kept.ts'),
+				'utf8',
+			);
 
-				assert.match(kept, /const value = 1;\n\n\treturn value;/);
-			},
+			assert.match(kept, /const value = 1;\n\n\treturn value;/);
+		},
 	);
 });
 
 test('adds blank lines above loops after simple statements only', async () => {
 	await withFixture(
 		{
-				'loops.ts': [
-					'function run(items: string[], map: Record<string, string>) {',
-					'\tlet count = 0;',
-					'\tcount++;',
-					'\tfor (; count < 1; count++) {',
-					'\t\tcount++;',
-					'\t}',
-					'\tcount++;',
-					'\tfor (const item of items) {',
-					'\t\tconsole.log(item);',
-					'\t}',
-					'\tcount++;',
-					'\tfor (const key in map) {',
-					'\t\tconsole.log(key);',
-					'\t}',
-					'\tcount++;',
-					'\twhile (count < 3) {',
-					'\t\tcount++;',
-					'\t}',
-					'\tcount++;',
-					'\tdo {',
-					'\t\tcount++;',
-					'\t} while (count < 4);',
-					'\tfunction local() {',
-					'\t\treturn count;',
-					'\t}',
-					'\tfor (; count < local(); count++) {',
-					'\t\tcount++;',
-					'\t}',
-					'\tif (count > 10) {',
-					'\t\tcount--;',
-					'\t}',
-					'\twhile (count > 0) {',
-					'\t\tcount--;',
-					'\t}',
-					'\ttype LoopCount = number;',
-					'\twhile (count < Number.MAX_SAFE_INTEGER) {',
-					'\t\tconst typedCount: LoopCount = count;',
-					'\t\tcount = typedCount + 1;',
-					'\t}',
-					'}',
-					'',
-				].join('\n'),
-			},
+			'loops.ts': [
+				'function run(items: string[], map: Record<string, string>) {',
+				'\tlet count = 0;',
+				'\tcount++;',
+				'\tfor (; count < 1; count++) {',
+				'\t\tcount++;',
+				'\t}',
+				'\tcount++;',
+				'\tfor (const item of items) {',
+				'\t\tconsole.log(item);',
+				'\t}',
+				'\tcount++;',
+				'\tfor (const key in map) {',
+				'\t\tconsole.log(key);',
+				'\t}',
+				'\tcount++;',
+				'\twhile (count < 3) {',
+				'\t\tcount++;',
+				'\t}',
+				'\tcount++;',
+				'\tdo {',
+				'\t\tcount++;',
+				'\t} while (count < 4);',
+				'\tfunction local() {',
+				'\t\treturn count;',
+				'\t}',
+				'\tfor (; count < local(); count++) {',
+				'\t\tcount++;',
+				'\t}',
+				'\tif (count > 10) {',
+				'\t\tcount--;',
+				'\t}',
+				'\twhile (count > 0) {',
+				'\t\tcount--;',
+				'\t}',
+				'\ttype LoopCount = number;',
+				'\twhile (count < Number.MAX_SAFE_INTEGER) {',
+				'\t\tconst typedCount: LoopCount = count;',
+				'\t\tcount = typedCount + 1;',
+				'\t}',
+				'}',
+				'',
+			].join('\n'),
+		},
 		async (dir) => {
-				run(process.execPath, ['--import', tsx, script, 'loops.ts'], dir);
-				run(process.execPath, ['--import', tsx, script, 'loops.ts'], dir);
+			run(
+				process.execPath,
+				['--import', tsx, script, 'loops.ts'],
+				dir,
+			);
+			run(
+				process.execPath,
+				['--import', tsx, script, 'loops.ts'],
+				dir,
+			);
 
-				const output = await readFile(join(dir, 'loops.ts'), 'utf8');
+			const output = await readFile(
+				join(dir, 'loops.ts'),
+				'utf8',
+			);
 
-				assert.match(output, /count\+\+;\n\n\tfor \(; count < 1; count\+\+\) \{/);
-				assert.match(output, /count\+\+;\n\n\tfor \(const item of items\) \{/);
-				assert.match(output, /count\+\+;\n\n\tfor \(const key in map\) \{/);
-				assert.match(output, /count\+\+;\n\n\twhile \(count < 3\) \{/);
-				assert.match(output, /count\+\+;\n\n\tdo \{/);
-				assert.match(output, /function local\(\) \{\n\t\treturn count;\n\t}\n\tfor \(; count < local\(\); count\+\+\) \{/);
-				assert.match(output, /if \(count > 10\) \{\n\t\tcount--;\n\t}\n\twhile \(count > 0\) \{/);
-				assert.match(output, /type LoopCount = number;\n\n\twhile \(count < Number\.MAX_SAFE_INTEGER\) \{/);
-			},
+			assert.match(output, /count\+\+;\n\n\tfor \(; count < 1; count\+\+\) \{/);
+			assert.match(output, /count\+\+;\n\n\tfor \(const item of items\) \{/);
+			assert.match(output, /count\+\+;\n\n\tfor \(const key in map\) \{/);
+			assert.match(output, /count\+\+;\n\n\twhile \(count < 3\) \{/);
+			assert.match(output, /count\+\+;\n\n\tdo \{/);
+			assert.match(output, /function local\(\) \{\n\t\treturn count;\n\t}\n\tfor \(; count < local\(\); count\+\+\) \{/);
+			assert.match(output, /if \(count > 10\) \{\n\t\tcount--;\n\t}\n\twhile \(count > 0\) \{/);
+			assert.match(output, /type LoopCount = number;\n\n\twhile \(count < Number\.MAX_SAFE_INTEGER\) \{/);
+		},
 	);
 });
 
 test('CLI uses modular formatter for body wrapping and declaration ordering', async () => {
 	await withFixture(
 		{
-				'tracked.ts': ['import {', '\ta,', '} from "a";', 'import { b } from "b";', 'function run() {', '\tif (ready) done();', '}', ''].join('\n'),
-			},
+			'tracked.ts': ['import {', '\ta,', '} from "a";', 'import { b } from "b";', 'function run() {', '\tif (ready) done();', '}', ''].join('\n'),
+		},
 		async (dir) => {
-				run(process.execPath, ['--import', tsx, script, 'tracked.ts'], dir);
+			run(
+				process.execPath,
+				['--import', tsx, script, 'tracked.ts'],
+				dir,
+			);
 
-				const tracked = await readFile(join(dir, 'tracked.ts'), 'utf8');
+			const tracked = await readFile(
+				join(dir, 'tracked.ts'),
+				'utf8',
+			);
 
-				assert.match(tracked, /import \{ b \} from "b";\n\nimport \{\n\ta,\n\} from "a";/);
-				assert.match(tracked, /if \(ready\) \{\n\t\tdone\(\);\n\t\}/);
-			},
+			assert.match(tracked, /import \{ b \} from "b";\n\nimport \{\n\ta,\n\} from "a";/);
+			assert.match(tracked, /if \(ready\) \{\n\t\tdone\(\);\n\t\}/);
+		},
 	);
 });

--- a/packages/ts/sidecar/src/expanded-calls.test.ts
+++ b/packages/ts/sidecar/src/expanded-calls.test.ts
@@ -89,7 +89,37 @@ describe('expanded call formatter', () => {
 		// it — oxfmt used to hide this by collapsing the call straight back.
 		const input = ['function send() {', '\tconst response = fetch(url, {', '\t\t...init,', '\t\theaders,', '\t});', '}', ''].join('\n');
 		const expected = ['function send() {', '\tconst response = fetch(', '\t\turl,', '\t\t{', '\t\t\t...init,', '\t\t\theaders,', '\t\t},', '\t);', '}', ''].join('\n');
+		const once = ExpandedCalls.format(input, 'fixture.ts');
 
-		assert.equal(ExpandedCalls.format(input, 'fixture.ts'), expected);
+		assert.equal(once, expected);
+
+		// The rebase reads its origin off the argument's own line, so an argument
+		// already sitting at its target depth is left where it is.
+		assert.equal(ExpandedCalls.format(once, 'fixture.ts'), expected);
+	});
+
+	it('never re-indents the interior of a multiline template literal', () => {
+		// The literal's leading whitespace is string content. Re-indenting it made
+		// every pass shift the value one unit further right (issue #59).
+		const input = ['const Harness = defineComponent({', '    template: `', '        <div>', '            <span>hello</span>', '        </div>', '    `,', '});', ''].join('\n');
+
+		const expected = ['const Harness = defineComponent(', '    {', '        template: `', '        <div>', '            <span>hello</span>', '        </div>', '    `,', '    },', ');', ''].join(
+			'\n',
+		);
+
+		const once = ExpandedCalls.format(input, 'fixture.ts');
+
+		assert.equal(once, expected);
+
+		assert.equal(ExpandedCalls.format(once, 'fixture.ts'), expected);
+	});
+
+	it('preserves whitespace-only lines inside a template literal', () => {
+		const input = ['const query = run(build(), {', '\tsql: `', '\t\tselect 1', '   ', '\t\tfrom t', '\t`,', '});', ''].join('\n');
+		const output = ExpandedCalls.format(input, 'fixture.ts');
+
+		assert.ok(output.includes('\n   \n'), 'a blank line carrying string content must keep its bytes');
+
+		assert.equal(ExpandedCalls.format(output, 'fixture.ts'), output);
 	});
 });

--- a/packages/ts/sidecar/src/expanded-calls.test.ts
+++ b/packages/ts/sidecar/src/expanded-calls.test.ts
@@ -122,4 +122,80 @@ describe('expanded call formatter', () => {
 
 		assert.equal(ExpandedCalls.format(output, 'fixture.ts'), output);
 	});
+
+	/** The source between the first and last backtick — a template's literal bytes. */
+	const templateBody = (source: string): string => {
+		return source.slice(source.indexOf('`') + 1, source.lastIndexOf('`'));
+	};
+
+	it('reaches a fixed point for a tab-indented template literal', () => {
+		const input = ['const Harness = defineComponent({', '\ttemplate: `', '\t\t<div>', '\t\t\t<span>hello</span>', '\t\t</div>', '\t`,', '});', ''].join('\n');
+		const once = ExpandedCalls.format(input, 'fixture.ts');
+
+		assert.notEqual(once, input, 'the call should have expanded');
+
+		assert.equal(ExpandedCalls.format(once, 'fixture.ts'), once);
+
+		assert.equal(templateBody(once), templateBody(input), 'template interior bytes must be preserved');
+	});
+
+	it('reaches a fixed point for a template literal with multiline interpolations', () => {
+		const input = [
+			'const q = build({',
+			'    query: `',
+			'        SELECT *',
+			'        FROM ${',
+			'            resolveTable(schema)',
+			'        }',
+			`        WHERE id = \${id}`,
+			'    `,',
+			'});',
+			'',
+		].join('\n');
+
+		const once = ExpandedCalls.format(input, 'fixture.ts');
+
+		assert.notEqual(once, input, 'the call should have expanded');
+
+		assert.equal(ExpandedCalls.format(once, 'fixture.ts'), once);
+
+		assert.equal(templateBody(once), templateBody(input), 'template interior bytes must be preserved');
+	});
+
+	it('reaches a fixed point for a tagged template literal', () => {
+		const input = ['const styled = create({', '    styles: css`', '        color: red;', `        margin: \${spacing}px;`, '    `,', '});', ''].join('\n');
+		const once = ExpandedCalls.format(input, 'fixture.ts');
+
+		assert.notEqual(once, input, 'the call should have expanded');
+
+		assert.equal(ExpandedCalls.format(once, 'fixture.ts'), once);
+
+		assert.equal(templateBody(once), templateBody(input), 'template interior bytes must be preserved');
+	});
+
+	it('converges over a template literal nested two expansions deep', () => {
+		// The pass lifts one nesting level per run, so the inner call expands on a
+		// later pass than the outer one. Convergence is what matters: once every
+		// level has expanded, further passes are a no-op and the literal is intact.
+		const input = ['const app = createApp({', '    root: defineComponent({', '        template: `', '            <div>deep</div>', '        `,', '    }),', '});', ''].join('\n');
+
+		let current = input;
+
+		for (let i = 0; i < 5; i++) {
+			const next = ExpandedCalls.format(current, 'fixture.ts');
+
+			if (next === current) {
+				break;
+			}
+
+			current = next;
+		}
+
+		assert.notEqual(current, input, 'both calls should have expanded');
+		assert.match(current, /root: defineComponent\(\n/, 'the inner call must also expand');
+
+		assert.equal(ExpandedCalls.format(current, 'fixture.ts'), current, 'the fixed point must be stable');
+
+		assert.equal(templateBody(current), templateBody(input), 'template interior bytes must be preserved');
+	});
 });

--- a/packages/ts/sidecar/src/expanded-calls.ts
+++ b/packages/ts/sidecar/src/expanded-calls.ts
@@ -6,6 +6,7 @@ import { isErr } from '#sidecar/result';
 import { SourceText } from '#sidecar/source-text';
 import type { CallParens } from '#sidecar/source-text';
 import { Sources } from '#sidecar/sources';
+import { TemplateSpans } from '#sidecar/template-spans';
 import type { Edit } from '#sidecar/types';
 
 const FUNCTION_TYPES = new Set(['ArrowFunctionExpression', 'FunctionDeclaration', 'FunctionExpression']);
@@ -114,38 +115,56 @@ export class ExpandedCalls {
 		return arg?.type !== 'SpreadElement';
 	}
 
+	static #rebaseLine(line: string, lineStart: number, from: string, to: string, spans: TemplateSpans): string {
+		// A template literal's leading whitespace is string content, not
+		// indentation: moving it would rewrite the value, and since oxfmt hugs the
+		// expanded call back onto one line before the next run re-expands it, every
+		// run would shift the literal one level further right.
+		if (spans.contains(lineStart)) {
+			return line;
+		}
+
+		if (line.trim() === '') {
+			return '';
+		}
+
+		return line.startsWith(from) ? `${to}${line.slice(from.length)}` : line;
+	}
+
 	/**
 	 * Re-indent lifted source so its continuation lines match where it now sits.
 	 *
-	 * An argument's text is copied out of the call site verbatim, so its second and
-	 * later lines are still indented relative to the statement the call started on
-	 * (`from`). Expanding the call moves the argument one or more levels deeper
-	 * (`to`), and without rebasing those lines they keep the shallower depth and the
-	 * block reads inside-out. Only the first line is left alone — the caller places
-	 * it.
+	 * A node's text is copied out of the call site verbatim, so its second and
+	 * later lines are still indented relative to the line the node was written on.
+	 * Expanding the call moves the node one or more levels deeper (`to`), and
+	 * without rebasing those lines they keep the shallower depth and the block
+	 * reads inside-out. Reading the origin off the node's own line, rather than off
+	 * the call being expanded, is what makes a second run a no-op: text already
+	 * sitting at its target depth is left alone. Only the first line is skipped
+	 * outright — the caller places it.
 	 */
-	static #rebaseIndent(text: string, from: string, to: string): string {
+	static #rebaseIndent(source: string, node: Node, to: string, spans: TemplateSpans): string {
+		const start = Ast.getStart(node);
+		const text = SourceText.sourceOf(source, node);
+		const from = SourceText.lineIndent(source, start);
+
 		if (from === to || !text.includes('\n')) {
 			return text;
 		}
 
-		return text
-			.split('\n')
-			.map((line, index) => {
-				if (index === 0) {
-					return line;
-				}
+		const rebased: string[] = [];
 
-				if (line.trim() === '') {
-					return '';
-				}
+		let lineStart = start;
 
-				return line.startsWith(from) ? `${to}${line.slice(from.length)}` : line;
-			})
-			.join('\n');
+		for (const [index, line] of text.split('\n').entries()) {
+			rebased.push(index === 0 ? line : ExpandedCalls.#rebaseLine(line, lineStart, from, to, spans));
+			lineStart += line.length + 1;
+		}
+
+		return rebased.join('\n');
 	}
 
-	static #formatCallParens(source: string, call: Node, comments: readonly Node[], indent: string, baseIndent: string, indentUnit: string): string | null {
+	static #formatCallParens(source: string, call: Node, comments: readonly Node[], indent: string, indentUnit: string, spans: TemplateSpans): string | null {
 		const parens = ExpandedCalls.#calleeParens(source, call);
 		const args = ExpandedCalls.#callArguments(call);
 
@@ -160,7 +179,7 @@ export class ExpandedCalls {
 		const argIndent = `${indent}${indentUnit}`;
 
 		const formattedArgs = args.map((arg) => {
-			return ExpandedCalls.#formatNode(source, arg, comments, argIndent, baseIndent, indentUnit);
+			return ExpandedCalls.#formatNode(source, arg, comments, argIndent, indentUnit, spans);
 		});
 
 		const separator = `,\n${argIndent}`;
@@ -169,30 +188,30 @@ export class ExpandedCalls {
 		return `(\n${argIndent}${formattedArgs.join(separator)}${trailingComma}\n${indent})`;
 	}
 
-	static #formatCall(source: string, call: Node, comments: readonly Node[], indent: string, baseIndent: string, indentUnit: string): string {
+	static #formatCall(source: string, call: Node, comments: readonly Node[], indent: string, indentUnit: string, spans: TemplateSpans): string {
 		const parens = ExpandedCalls.#calleeParens(source, call);
-		const formattedParens = ExpandedCalls.#formatCallParens(source, call, comments, indent, baseIndent, indentUnit);
+		const formattedParens = ExpandedCalls.#formatCallParens(source, call, comments, indent, indentUnit, spans);
 
 		if (!parens || formattedParens === null) {
-			return ExpandedCalls.#rebaseIndent(SourceText.sourceOf(source, call), baseIndent, indent);
+			return ExpandedCalls.#rebaseIndent(source, call, indent, spans);
 		}
 
 		return `${source.slice(Ast.getStart(call), parens.open)}${formattedParens}`;
 	}
 
-	// indent is where node will sit once expanded; baseIndent is where its source
-	// text came from and is threaded down unchanged, because nothing has moved in
-	// the source yet however deep the recursion goes.
-	static #formatNode(source: string, node: Node, comments: readonly Node[], indent: string, baseIndent: string, indentUnit: string): string {
+	// indent is where node will sit once expanded; the depth its text came from is
+	// read back off the node's own line, because nothing has moved in the source
+	// yet however deep the recursion goes.
+	static #formatNode(source: string, node: Node, comments: readonly Node[], indent: string, indentUnit: string, spans: TemplateSpans): string {
 		if (node.type !== 'CallExpression') {
-			return ExpandedCalls.#rebaseIndent(SourceText.sourceOf(source, node), baseIndent, indent);
+			return ExpandedCalls.#rebaseIndent(source, node, indent, spans);
 		}
 
 		if (!ExpandedCalls.#shouldExpandCall(node)) {
-			return ExpandedCalls.#rebaseIndent(SourceText.sourceOf(source, node), baseIndent, indent);
+			return ExpandedCalls.#rebaseIndent(source, node, indent, spans);
 		}
 
-		return ExpandedCalls.#formatCall(source, node, comments, indent, baseIndent, indentUnit);
+		return ExpandedCalls.#formatCall(source, node, comments, indent, indentUnit, spans);
 	}
 	/**
 	 * Compute edits for calls whose arguments require a multiline layout.
@@ -216,6 +235,7 @@ export class ExpandedCalls {
 		const parents = new WeakMap<Node, Node>();
 		const edits: Edit[] = [];
 		const indentUnit = SourceText.detectIndentUnit(content);
+		const spans = TemplateSpans.collect(parsed.value.program);
 
 		ExpandedCalls.#collectParents(parsed.value.program, parents);
 
@@ -240,7 +260,7 @@ export class ExpandedCalls {
 
 			const indent = SourceText.lineIndent(content, Ast.getStart(node));
 
-			const replacement = ExpandedCalls.#formatCallParens(content, node, comments, indent, indent, indentUnit);
+			const replacement = ExpandedCalls.#formatCallParens(content, node, comments, indent, indentUnit, spans);
 			const current = content.slice(parens.open, parens.close + 1);
 
 			if (replacement === null || replacement === current) {

--- a/packages/ts/sidecar/src/fluent-chains.test.ts
+++ b/packages/ts/sidecar/src/fluent-chains.test.ts
@@ -109,25 +109,51 @@ describe('fluent chain formatter', () => {
 		assert.equal(FluentChains.format(input, 'fixture.ts'), input);
 	});
 
+	it('reaches a fixed point over an expanded multiline template literal', () => {
+		// Issue #59: the literal's interior gained one indent unit per run, so no
+		// committed byte state survived another pass.
+		const interior = ['        <div>', '            <span>hello</span>', '        </div>'];
+		const input = ['const Harness = defineComponent({', '    template: `', ...interior, '    `,', '});', ''].join('\n');
+		const once = FluentChains.format(input, 'fixture.ts');
+		const twice = FluentChains.format(once, 'fixture.ts');
+
+		assert.equal(twice, once);
+
+		assert.equal(FluentChains.format(twice, 'fixture.ts'), once);
+
+		assert.ok(once.includes(interior.join('\n')), 'the literal interior must keep its original bytes');
+	});
+
 	it('formats Vue script blocks through the CLI', async () => {
 		await withFixture(
 			{
-					'DashboardRoute.vue': [
-						'<script setup lang="ts">',
-						"export const meRoutes = createRouter<{ Bindings: WorkerEnv; Variables: IdentityVariables }>().use('*', bindEnv).use(identityMiddleware).get('/', getMe).get('/sessions', getSessions);",
-						'</script>',
-						'',
-					].join('\n'),
-				},
+				'DashboardRoute.vue': [
+					'<script setup lang="ts">',
+					"export const meRoutes = createRouter<{ Bindings: WorkerEnv; Variables: IdentityVariables }>().use('*', bindEnv).use(identityMiddleware).get('/', getMe).get('/sessions', getSessions);",
+					'</script>',
+					'',
+				].join('\n'),
+			},
 			async (dir) => {
-					run(process.execPath, ['--import', tsx, script, 'DashboardRoute.vue'], dir);
-					run(process.execPath, ['--import', tsx, script, 'DashboardRoute.vue'], dir);
+				run(
+					process.execPath,
+					['--import', tsx, script, 'DashboardRoute.vue'],
+					dir,
+				);
+				run(
+					process.execPath,
+					['--import', tsx, script, 'DashboardRoute.vue'],
+					dir,
+				);
 
-					const output = await readFile(join(dir, 'DashboardRoute.vue'), 'utf8');
+				const output = await readFile(
+					join(dir, 'DashboardRoute.vue'),
+					'utf8',
+				);
 
-					assert.match(output, /createRouter<\{ Bindings: WorkerEnv; Variables: IdentityVariables \}>\(\)\n\t\.use\('\*', bindEnv\)\n\t\.use\(identityMiddleware\)/);
-					assert.match(output, /\.get\('\/', getMe\)\n\t\.get\('\/sessions', getSessions\);/);
-				},
+				assert.match(output, /createRouter<\{ Bindings: WorkerEnv; Variables: IdentityVariables \}>\(\)\n\t\.use\('\*', bindEnv\)\n\t\.use\(identityMiddleware\)/);
+				assert.match(output, /\.get\('\/', getMe\)\n\t\.get\('\/sessions', getSessions\);/);
+			},
 		);
 	});
 
@@ -136,69 +162,98 @@ describe('fluent chain formatter', () => {
 
 		await withFixture(
 			{
-					'StructuredData.vue': [
-						'<script type="application/ld+json">',
-						jsonLd,
-						'</script>',
-						'<script setup lang="ts">',
-						"export const meRoutes = createRouter().use('*', bindEnv).get('/', getMe);",
-						'</script>',
-						'',
-					].join('\n'),
-				},
+				'StructuredData.vue': [
+					'<script type="application/ld+json">',
+					jsonLd,
+					'</script>',
+					'<script setup lang="ts">',
+					"export const meRoutes = createRouter().use('*', bindEnv).get('/', getMe);",
+					'</script>',
+					'',
+				].join('\n'),
+			},
 			async (dir) => {
-					run(process.execPath, ['--import', tsx, script, 'StructuredData.vue'], dir);
+				run(
+					process.execPath,
+					['--import', tsx, script, 'StructuredData.vue'],
+					dir,
+				);
 
-					const output = await readFile(join(dir, 'StructuredData.vue'), 'utf8');
+				const output = await readFile(
+					join(dir, 'StructuredData.vue'),
+					'utf8',
+				);
 
-					assert.ok(output.includes(['<script type="application/ld+json">', jsonLd, '</script>'].join('\n')));
-					assert.match(output, /createRouter\(\)\n\t\.use\('\*', bindEnv\)\n\t\.get\('\/', getMe\);/);
-				},
+				assert.ok(output.includes(['<script type="application/ld+json">', jsonLd, '</script>'].join('\n')));
+				assert.match(output, /createRouter\(\)\n\t\.use\('\*', bindEnv\)\n\t\.get\('\/', getMe\);/);
+			},
 		);
 	});
 
 	it('formats Drizzle queries in Vue script blocks through the CLI', async () => {
 		await withFixture(
 			{
-					'DashboardData.vue': [
-						'<script setup lang="ts">',
-						"import { and, eq, gt } from 'drizzle-orm';",
-						'const rows = await db.select().from(sessions).where(and(eq(sessions.userId, userId), gt(sessions.expiresAt, now)));',
-						'</script>',
-						'',
-					].join('\n'),
-				},
+				'DashboardData.vue': [
+					'<script setup lang="ts">',
+					"import { and, eq, gt } from 'drizzle-orm';",
+					'const rows = await db.select().from(sessions).where(and(eq(sessions.userId, userId), gt(sessions.expiresAt, now)));',
+					'</script>',
+					'',
+				].join('\n'),
+			},
 			async (dir) => {
-					run(process.execPath, ['--import', tsx, script, 'DashboardData.vue'], dir);
-					run(process.execPath, ['--import', tsx, script, 'DashboardData.vue'], dir);
+				run(
+					process.execPath,
+					['--import', tsx, script, 'DashboardData.vue'],
+					dir,
+				);
+				run(
+					process.execPath,
+					['--import', tsx, script, 'DashboardData.vue'],
+					dir,
+				);
 
-					const output = await readFile(join(dir, 'DashboardData.vue'), 'utf8');
+				const output = await readFile(
+					join(dir, 'DashboardData.vue'),
+					'utf8',
+				);
 
-					assert.match(output, /\.where\(\n\t\tand\(\n\t\t\teq\(sessions\.userId, userId\),\n\t\t\tgt\(sessions\.expiresAt, now\),\n\t\t\),\n\t\);/);
-				},
+				assert.match(output, /\.where\(\n\t\tand\(\n\t\t\teq\(sessions\.userId, userId\),\n\t\t\tgt\(sessions\.expiresAt, now\),\n\t\t\),\n\t\);/);
+			},
 		);
 	});
 
 	it('formats expanded call arguments in Vue script blocks through the CLI', async () => {
 		await withFixture(
 			{
-					'AuthProvider.vue': [
-						'<script setup lang="ts">',
-						'function createAuth() {',
-						'\treturn betterAuth(buildAuthConfig(env, db, mailer, app, options)) as unknown as SasuAuth;',
-						'}',
-						'</script>',
-						'',
-					].join('\n'),
-				},
+				'AuthProvider.vue': [
+					'<script setup lang="ts">',
+					'function createAuth() {',
+					'\treturn betterAuth(buildAuthConfig(env, db, mailer, app, options)) as unknown as SasuAuth;',
+					'}',
+					'</script>',
+					'',
+				].join('\n'),
+			},
 			async (dir) => {
-					run(process.execPath, ['--import', tsx, script, 'AuthProvider.vue'], dir);
-					run(process.execPath, ['--import', tsx, script, 'AuthProvider.vue'], dir);
+				run(
+					process.execPath,
+					['--import', tsx, script, 'AuthProvider.vue'],
+					dir,
+				);
+				run(
+					process.execPath,
+					['--import', tsx, script, 'AuthProvider.vue'],
+					dir,
+				);
 
-					const output = await readFile(join(dir, 'AuthProvider.vue'), 'utf8');
+				const output = await readFile(
+					join(dir, 'AuthProvider.vue'),
+					'utf8',
+				);
 
-					assert.match(output, /return betterAuth\(\n\t\tbuildAuthConfig\(env, db, mailer, app, options\),\n\t\) as unknown as SasuAuth;/);
-				},
+				assert.match(output, /return betterAuth\(\n\t\tbuildAuthConfig\(env, db, mailer, app, options\),\n\t\) as unknown as SasuAuth;/);
+			},
 		);
 	});
 });

--- a/packages/ts/sidecar/src/package.json
+++ b/packages/ts/sidecar/src/package.json
@@ -49,6 +49,8 @@
 		"#sidecar/source-text.js": "./source-text.ts",
 		"#sidecar/sources": "./sources.ts",
 		"#sidecar/sources.js": "./sources.ts",
+		"#sidecar/template-spans": "./template-spans.ts",
+		"#sidecar/template-spans.js": "./template-spans.ts",
 		"#sidecar/types": "./types.ts",
 		"#sidecar/vue-script": "./vue-script.ts",
 		"#sidecar/vue-script.js": "./vue-script.ts",

--- a/packages/ts/sidecar/src/template-spans.test.ts
+++ b/packages/ts/sidecar/src/template-spans.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { isErr } from '#sidecar/result';
+import { Sources } from '#sidecar/sources';
+import { TemplateSpans } from '#sidecar/template-spans';
+
+function spansOf(source: string): TemplateSpans | null {
+	const parsed = Sources.parse('fixture.ts', source);
+
+	return isErr(parsed) ? null : TemplateSpans.collect(parsed.value.program);
+}
+
+test('TemplateSpans.contains covers a literal interior but not the line that opens it', () => {
+	const source = ['const markup = `', '\t<div>', '\t\t<span>hello</span>', '\t</div>', '`;', ''].join('\n');
+	const spans = spansOf(source);
+
+	assert.notEqual(spans, null);
+
+	assert.equal(spans?.contains(source.indexOf('const')), false);
+
+	assert.equal(spans?.contains(source.indexOf('`')), false);
+
+	assert.equal(spans?.contains(source.indexOf('\t<div>')), true);
+
+	assert.equal(spans?.contains(source.indexOf('\t\t<span>')), true);
+
+	// The closing backtick still carries the literal's last line.
+	assert.equal(spans?.contains(source.lastIndexOf('`')), true);
+
+	assert.equal(spans?.contains(source.length - 1), false);
+});
+
+test('TemplateSpans.collect covers tagged, nested, and interpolated literals', () => {
+	const source = ['const query = sql`', '\tselect ${column(`', '\t\tinner', '\t`)}', '`;', ''].join('\n');
+	const spans = spansOf(source);
+
+	assert.notEqual(spans, null);
+
+	assert.equal(spans?.contains(source.indexOf('\tselect')), true);
+
+	assert.equal(spans?.contains(source.indexOf('\t\tinner')), true);
+});
+
+test('TemplateSpans.contains is false for source without a template literal', () => {
+	const spans = spansOf(
+		["const value = 'plain';", ''].join('\n'),
+	);
+
+	assert.notEqual(spans, null);
+
+	assert.equal(spans?.contains(5), false);
+});

--- a/packages/ts/sidecar/src/template-spans.ts
+++ b/packages/ts/sidecar/src/template-spans.ts
@@ -1,0 +1,61 @@
+import { Ast } from '#sidecar/ast';
+import type { Node } from '#sidecar/types';
+
+type Span = readonly [number, number];
+
+/** Locates the template-literal source that formatting passes must not re-indent. */
+export class TemplateSpans {
+	readonly #spans: readonly Span[];
+
+	private constructor(spans: Span[]) {
+		this.#spans = Object.freeze(spans);
+
+		Object.freeze(this);
+	}
+
+	/**
+	 * Collect every template literal below a parsed program.
+	 *
+	 * Whole literals are recorded rather than their quasis, so the interior of a
+	 * multiline `${...}` expression is preserved along with the string chunks
+	 * around it. Tagged templates need no special case: their `quasi` is itself a
+	 * template literal and is visited.
+	 *
+	 * @param program - The program root to traverse.
+	 * @returns The literal spans, in depth-first traversal order.
+	 */
+	static collect(program: Node): TemplateSpans {
+		const spans: Span[] = [];
+
+		Ast.visit(program, (node) => {
+			if (node.type !== 'TemplateLiteral') {
+				return;
+			}
+
+			const start = Ast.getStart(node);
+			const end = Ast.getEnd(node);
+
+			if (start >= 0 && end >= 0) {
+				spans.push([start, end]);
+			}
+		});
+
+		return new TemplateSpans(spans);
+	}
+
+	/**
+	 * Report whether an offset sits inside a template literal's own text.
+	 *
+	 * The literal's opening offset is excluded because the code that opens the
+	 * literal shares that line and may still be re-indented; every later offset,
+	 * up to and including the closing backtick, carries string content.
+	 *
+	 * @param offset - The source offset to test.
+	 * @returns `true` when the offset falls inside a literal.
+	 */
+	contains(offset: number): boolean {
+		return this.#spans.some(([start, end]) => {
+			return start < offset && offset < end;
+		});
+	}
+}

--- a/packages/ts/sidecar/src/validate-syntax.test.ts
+++ b/packages/ts/sidecar/src/validate-syntax.test.ts
@@ -45,74 +45,94 @@ async function withFixture(files: Record<string, string>, fn: (dir: string) => P
 test('accepts valid TypeScript and Vue script blocks', async () => {
 	await withFixture(
 		{
-				'valid.ts': 'const value = computed(() => source.value.trim().toLowerCase());\n',
-				'Valid.vue': '<script setup lang="ts">\nconst value = 1;\n</script>\n<template>{{ value }}</template>\n',
-			},
+			'valid.ts': 'const value = computed(() => source.value.trim().toLowerCase());\n',
+			'Valid.vue': '<script setup lang="ts">\nconst value = 1;\n</script>\n<template>{{ value }}</template>\n',
+		},
 		async (dir) => {
-				const result = spawnSync(process.execPath, ['--import', tsx, script, 'valid.ts', 'Valid.vue'], { cwd: dir, encoding: 'utf8' });
+			const result = spawnSync(
+				process.execPath,
+				['--import', tsx, script, 'valid.ts', 'Valid.vue'],
+				{ cwd: dir, encoding: 'utf8' },
+			);
 
-				assert.equal(result.status, 0, result.stderr || result.stdout);
-				assert.match(result.stdout, /\[validate-syntax\] checked 2 file\(s\)/);
-			},
+			assert.equal(result.status, 0, result.stderr || result.stdout);
+			assert.match(result.stdout, /\[validate-syntax\] checked 2 file\(s\)/);
+		},
 	);
 });
 
 test('accepts Vue TSX and JSX script blocks', async () => {
 	await withFixture(
 		{
-				'Component.vue': '<script setup lang="tsx">\nconst view = <section>Ready</section>;\n</script>\n',
-				'Legacy.vue': "<script lang='jsx'>\nconst view = <section>Ready</section>;\n</script>\n",
-			},
+			'Component.vue': '<script setup lang="tsx">\nconst view = <section>Ready</section>;\n</script>\n',
+			'Legacy.vue': "<script lang='jsx'>\nconst view = <section>Ready</section>;\n</script>\n",
+		},
 		async (dir) => {
-				const result = spawnSync(process.execPath, ['--import', tsx, script, 'Component.vue', 'Legacy.vue'], { cwd: dir, encoding: 'utf8' });
+			const result = spawnSync(
+				process.execPath,
+				['--import', tsx, script, 'Component.vue', 'Legacy.vue'],
+				{ cwd: dir, encoding: 'utf8' },
+			);
 
-				assert.equal(result.status, 0, result.stderr || result.stdout);
-				assert.match(result.stdout, /\[validate-syntax\] checked 2 file\(s\)/);
-			},
+			assert.equal(result.status, 0, result.stderr || result.stdout);
+			assert.match(result.stdout, /\[validate-syntax\] checked 2 file\(s\)/);
+		},
 	);
 });
 
 test('reports Vue syntax errors on original file lines', async () => {
 	await withFixture(
 		{
-				'Broken.vue': '<template>\n\t<div />\n</template>\n<script setup lang="ts">\nconst broken = ;\n</script>\n',
-			},
+			'Broken.vue': '<template>\n\t<div />\n</template>\n<script setup lang="ts">\nconst broken = ;\n</script>\n',
+		},
 		async (dir) => {
-				const result = spawnSync(process.execPath, ['--import', tsx, script, 'Broken.vue'], { cwd: dir, encoding: 'utf8' });
+			const result = spawnSync(
+				process.execPath,
+				['--import', tsx, script, 'Broken.vue'],
+				{ cwd: dir, encoding: 'utf8' },
+			);
 
-				assert.equal(result.status, 1);
-				assert.match(result.stderr, /\[validate-syntax\].*Broken\.vue/);
-				assert.match(result.stderr, /5 \| const broken = ;/);
-			},
+			assert.equal(result.status, 1);
+			assert.match(result.stderr, /\[validate-syntax\].*Broken\.vue/);
+			assert.match(result.stderr, /5 \| const broken = ;/);
+		},
 	);
 });
 
 test('fails with a clear diagnostic for corrupted formatter output', async () => {
 	await withFixture(
 		{
-				'useAppController.ts': 'const normalizedDebouncedSearch = computed(() => debouncedSearch.value.trim().toLowerCase()););\n',
-			},
+			'useAppController.ts': 'const normalizedDebouncedSearch = computed(() => debouncedSearch.value.trim().toLowerCase()););\n',
+		},
 		async (dir) => {
-				const result = spawnSync(process.execPath, ['--import', tsx, script, 'useAppController.ts'], { cwd: dir, encoding: 'utf8' });
+			const result = spawnSync(
+				process.execPath,
+				['--import', tsx, script, 'useAppController.ts'],
+				{ cwd: dir, encoding: 'utf8' },
+			);
 
-				assert.equal(result.status, 1);
-				assert.match(result.stderr, /\[validate-syntax\].*useAppController\.ts/);
-				assert.match(result.stderr, /Unexpected token/);
-			},
+			assert.equal(result.status, 1);
+			assert.match(result.stderr, /\[validate-syntax\].*useAppController\.ts/);
+			assert.match(result.stderr, /Unexpected token/);
+		},
 	);
 });
 
 test('skips missing paths and ignores non-source arguments', async () => {
 	await withFixture(
 		{
-				'notes.md': '# Notes\n',
-			},
+			'notes.md': '# Notes\n',
+		},
 		async (dir) => {
-				const result = spawnSync(process.execPath, ['--import', tsx, script, 'missing.ts', 'notes.md'], { cwd: dir, encoding: 'utf8' });
+			const result = spawnSync(
+				process.execPath,
+				['--import', tsx, script, 'missing.ts', 'notes.md'],
+				{ cwd: dir, encoding: 'utf8' },
+			);
 
-				assert.equal(result.status, 0, result.stderr || result.stdout);
-				assert.match(result.stderr, /\[validate-syntax\] path not found, skipping: missing\.ts/);
-				assert.match(result.stdout, /\[validate-syntax\] checked 1 file\(s\)/);
-			},
+			assert.equal(result.status, 0, result.stderr || result.stdout);
+			assert.match(result.stderr, /\[validate-syntax\] path not found, skipping: missing\.ts/);
+			assert.match(result.stdout, /\[validate-syntax\] checked 1 file\(s\)/);
+		},
 	);
 });


### PR DESCRIPTION
Fixes #59.

## The bug

A multiline template literal inside a call the sidecar expands gained **one indent unit on its interior lines every run**, so output never reached a fixed point and a `format-then-git-diff` drift gate could never pass. Verified drifting 4 → 8 → 12 spaces locally with the issue's repro.

Two defects in `ExpandedCalls.#rebaseIndent` compounded:

1. **Template interiors were treated as code.** Every continuation line of a lifted argument had its leading whitespace rewritten, including lines that are string content. Since `format-all` runs oxfmt *before* this pass, and oxfmt hugs the object argument back onto the call line each run while leaving string bytes alone, every run re-entered the expansion from the hugged shape and shifted the literal one more level right.
2. **The rebase origin was the call's line, not the node's.** `baseIndent` was threaded down from the call site, so a multiline argument already at its target depth was shifted *again* on a second run.

## The fix

- **New `TemplateSpans`** (`packages/ts/sidecar/src/template-spans.ts`): collects whole `TemplateLiteral` spans from a parsed program (so multiline `${…}` interiors are byte-preserved too) and answers `contains(offset)`. Registered in both `package.json` import maps.
- **`expanded-calls.ts`**: lines whose start offset falls inside a literal are returned verbatim — checked *before* the blank-line branch, so whitespace-only lines carrying string content keep their bytes. `baseIndent` is gone; each rebase reads `SourceText.lineIndent` at the node's own start, making `ExpandedCalls.format` idempotent on its own output.
- **Tests**: new `template-spans.test.ts`; the issue's repro plus fixed-point assertions in `expanded-calls.test.ts`; an end-to-end three-run stability test in `fluent-chains.test.ts`.

`DrizzleQueries`, `ClassReorder`, and `DeclarationReorder` need no change — they re-emit leaf slices verbatim and never rewrite continuation-line indentation.

## For the reviewer: why the test-file diffs are large

`blank-lines.test.ts`, `validate-syntax.test.ts`, and parts of `fluent-chains.test.ts` show formatting-only hunks. These are **this fix correcting formatting the old bug had baked into the tree**, applied by fmtkit itself — not unrelated churn:

- The old pipeline was *stable* but parked multiline arguments **one indent level too deep**: oxfmt normalized them, the pass re-added the level every run. Those hunks are the level coming back off.
- With the outer call's edit no longer changing anything every run, it stops shadowing nested edits through `Edits.nonOverlapping`, so previously-suppressed calls (e.g. `spawnSync(...)`, `run(...)`) now expand.

I confirmed on a stashed baseline that `format-all` was clean on `main`, so these hunks come from this change. No assertions or fixture contents were altered.

## Verification

- Repro loop: `pass 1 changed=true`, `pass 2 changed=false`, `pass 3 changed=false`; interior bytes identical to input.
- `oxfmt(sidecar(A)) == A` byte-for-byte — the full pipeline now has a fixed point.
- `fmtkit format-all` run four times over the repo: no change after the first (so `./infra/task.sh self-check` should stay green).
- `pnpm test` (129 sidecar + Go suites), `tsc --noEmit`, `oxlint`: all clean. Sidecar coverage 96.71% lines, `template-spans.ts` at 100%.

Once released, `oullin/gocanto-sh` can drop the `// prettier-ignore` on `workspace/app/src/components/__tests__/Command.test.ts`.