### PR TITLE
feat: derive oxfmt config from Prettier setups and honor .prettierignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,18 @@ concurrency: 0
 
 The TS/Vue layer runs [`oxfmt`](https://www.npmjs.com/package/oxfmt) over your sources, then applies project-specific syntax passes for blank lines and fluent builder chains. The binary ships a bundled `.oxfmtrc.json` (tabs, single quotes, trailing commas, 200-column width) that is applied by default, so you get the same style out of the box without any setup.
 
-A project-local oxfmt config takes precedence: if the directory being formatted contains its own `.oxfmtrc.*` (`.json`, `.jsonc`, `.ts`, `.js`, …), the bundled default is skipped and oxfmt uses yours. Override the bundled path explicitly with the `FMTKIT_OXFMTRC` environment variable, matching the other `FMTKIT_*` knobs.
+The config is resolved by precedence, first match wins:
+
+1. `FMTKIT_OXFMTRC` — an explicit path, matching the other `FMTKIT_*` knobs.
+2. A project-local `.oxfmtrc.*` (`.json`, `.jsonc`, `.ts`, `.js`, …) in the directory being formatted: the bundled default is skipped and oxfmt uses yours.
+3. A config derived from your Prettier setup: if the directory has a Prettier config (`.prettierrc*`, `prettier.config.*`, or a `"prettier"` key in `package.json`) but no oxfmt config, fmtkit translates it via `oxfmt --migrate=prettier` so a Prettier-configured project formats consistently with no extra setup. The translation is cached by the Prettier config's content hash, so it runs once and re-runs only when that config changes. If a config cannot be translated (a JS config importing project-local modules, say), fmtkit warns on stderr and falls back to the bundled default rather than failing the run.
+4. The bundled default.
+
+To opt out of the Prettier-derived step, drop in your own `.oxfmtrc.*`, which takes precedence over it.
+
+### Ignoring files (`.prettierignore`)
+
+`oxfmt` already honors `.prettierignore` (and `.gitignore`) in its own step. fmtkit extends that to the rest of the TS/Vue pipeline — the blank-line and fluent-chain passes and `oxlint --fix` — by filtering `.prettierignore`d paths out of the file set it collects, so an ignored file is left untouched by every lane. The matcher follows gitignore syntax (comments, negation, leading-`/` anchoring, trailing-`/` directories, and the `*`, `?`, `[…]`, and `**` wildcards). The Go formatter is unaffected: `.prettierignore` governs only the TS/Vue/HTML/Markdown lanes.
 
 ## What it formats
 

--- a/packages/go/driver/internal/sourcefiles/prettierignore.go
+++ b/packages/go/driver/internal/sourcefiles/prettierignore.go
@@ -1,0 +1,240 @@
+package sourcefiles
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+// prettierIgnore matches repo-relative paths against a parsed .prettierignore
+// file using gitignore semantics. Supported constructs: comments (#), blank
+// lines, negation (!, last match wins), leading-/ anchoring, trailing-/
+// directory patterns, and the * ? [...] and ** wildcards. Exotic constructs —
+// escaped leading #/! (\# and \!) and trailing-space escapes — are not
+// supported: a leading # or ! is always read as a comment or a negation.
+type prettierIgnore struct {
+	patterns []ignorePattern
+}
+
+// ignorePattern is one compiled .prettierignore line.
+type ignorePattern struct {
+	re      *regexp.Regexp
+	negated bool
+	dirOnly bool
+}
+
+// loadPrettierIgnore reads the .prettierignore at path and compiles it. It
+// returns nil (and no error) when the file is absent, so callers can treat "no
+// file" as "nothing filtered".
+func loadPrettierIgnore(path string) (*prettierIgnore, error) {
+	data, err := os.ReadFile(path)
+
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return compilePrettierIgnore(data), nil
+}
+
+// compilePrettierIgnore parses raw .prettierignore bytes into matchable
+// patterns, skipping blank lines, comments, and lines that fail to compile.
+func compilePrettierIgnore(data []byte) *prettierIgnore {
+	ignore := &prettierIgnore{}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if pattern, ok := compilePattern(line); ok {
+			ignore.patterns = append(ignore.patterns, pattern)
+		}
+	}
+
+	return ignore
+}
+
+// compilePattern turns one raw line into an ignorePattern, reporting false for
+// blank lines, comments, and lines whose glob yields an invalid regex — none of
+// which carry a usable pattern.
+func compilePattern(line string) (ignorePattern, bool) {
+	line = strings.TrimRight(line, "\r")
+	line = strings.TrimRight(line, " \t")
+
+	if line == "" || strings.HasPrefix(line, "#") {
+		return ignorePattern{}, false
+	}
+
+	negated := false
+
+	if strings.HasPrefix(line, "!") {
+		negated = true
+		line = line[1:]
+	}
+
+	dirOnly := false
+
+	if strings.HasSuffix(line, "/") {
+		dirOnly = true
+		line = strings.TrimSuffix(line, "/")
+	}
+
+	if line == "" {
+		return ignorePattern{}, false
+	}
+
+	anchored := strings.HasPrefix(line, "/") || strings.Contains(line, "/")
+
+	line = strings.TrimPrefix(line, "/")
+
+	body := translateGlob(line)
+
+	prefix := "(?:^|/)"
+
+	if anchored {
+		prefix = "^"
+	}
+
+	re, err := regexp.Compile(prefix + body + "$")
+
+	if err != nil {
+		return ignorePattern{}, false
+	}
+
+	return ignorePattern{
+		re:      re,
+		negated: negated,
+		dirOnly: dirOnly,
+	}, true
+}
+
+// ignores reports whether rel — a slash-separated path relative to the ignore
+// file's directory — is excluded. Later matches win, so a negation can
+// re-include a path an earlier pattern excluded.
+func (p *prettierIgnore) ignores(rel string) bool {
+	ignored := false
+
+	for _, pattern := range p.patterns {
+		if pattern.matches(rel) {
+			ignored = !pattern.negated
+		}
+	}
+
+	return ignored
+}
+
+// matches reports whether the pattern covers rel, either directly or because
+// one of rel's ancestor directories matches — excluding a directory excludes
+// everything beneath it.
+func (p ignorePattern) matches(rel string) bool {
+	if !p.dirOnly && p.re.MatchString(rel) {
+		return true
+	}
+
+	for i := 0; i < len(rel); i++ {
+		if rel[i] == '/' && p.re.MatchString(rel[:i]) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// translateGlob converts a gitignore-style glob body (no leading slash, no
+// trailing slash, no leading !) into a regular-expression fragment matched
+// against a slash-separated path. * and ? stay within one segment; ** spans
+// segments.
+func translateGlob(pattern string) string {
+	var b strings.Builder
+
+	for i := 0; i < len(pattern); {
+		switch c := pattern[i]; c {
+		case '*':
+			stars := i
+
+			for stars < len(pattern) && pattern[stars] == '*' {
+				stars++
+			}
+
+			doubled := stars-i >= 2
+
+			if doubled && stars < len(pattern) && pattern[stars] == '/' {
+				b.WriteString("(?:.*/)?")
+
+				i = stars + 1
+			} else if doubled {
+				b.WriteString(".*")
+
+				i = stars
+			} else {
+				b.WriteString("[^/]*")
+
+				i = stars
+			}
+		case '?':
+			b.WriteString("[^/]")
+
+			i++
+		case '[':
+			if class, next, ok := translateClass(pattern, i); ok {
+				b.WriteString(class)
+
+				i = next
+			} else {
+				b.WriteString("\\[")
+
+				i++
+			}
+		default:
+			if isRegexMeta(c) {
+				b.WriteByte('\\')
+			}
+
+			b.WriteByte(c)
+
+			i++
+		}
+	}
+
+	return b.String()
+}
+
+// translateClass converts the [...] character class starting at i into a regex
+// class, mapping a leading ! to ^. It reports false when the bracket has no
+// close, leaving the caller to treat [ literally.
+func translateClass(pattern string, i int) (string, int, bool) {
+	j := i + 1
+
+	if j < len(pattern) && (pattern[j] == '!' || pattern[j] == '^') {
+		j++
+	}
+
+	if j < len(pattern) && pattern[j] == ']' {
+		j++
+	}
+
+	for j < len(pattern) && pattern[j] != ']' {
+		j++
+	}
+
+	if j >= len(pattern) {
+		return "", 0, false
+	}
+
+	inner := pattern[i+1 : j]
+
+	if strings.HasPrefix(inner, "!") {
+		inner = "^" + inner[1:]
+	}
+
+	return "[" + inner + "]", j + 1, true
+}
+
+func isRegexMeta(c byte) bool {
+	switch c {
+	case '.', '\\', '+', '(', ')', '|', '{', '}', '^', '$', ']':
+		return true
+	default:
+		return false
+	}
+}

--- a/packages/go/driver/internal/sourcefiles/prettierignore_test.go
+++ b/packages/go/driver/internal/sourcefiles/prettierignore_test.go
@@ -1,0 +1,153 @@
+package sourcefiles
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestPrettierIgnoreMatches(t *testing.T) {
+	cases := []struct {
+		name     string
+		ignore   string
+		path     string
+		excluded bool
+	}{
+		{"blank and comment lines are inert", "\n# comment\n", "app.ts", false},
+		{"plain name matches at root", "app.ts\n", "app.ts", true},
+		{"plain name matches at any depth", "app.ts\n", "src/nested/app.ts", true},
+		{"plain name does not match a different file", "app.ts\n", "app.tsx", false},
+		{"leading slash anchors to root", "/app.ts\n", "app.ts", true},
+		{"leading slash rejects nested", "/app.ts\n", "src/app.ts", false},
+		{"trailing slash matches under a directory", "dist/\n", "dist/app.ts", true},
+		{"trailing slash does not match a file of that name", "dist/\n", "dist", false},
+		{"star stays within a segment", "*.ts\n", "src/app.ts", true},
+		{"star does not cross a slash", "src/*.ts\n", "src/nested/app.ts", false},
+		{"question matches one char", "app.?s\n", "app.ts", true},
+		{"question needs exactly one char", "app.?s\n", "app.tss", false},
+		{"character class matches a member", "app.[jt]s\n", "app.ts", true},
+		{"character class rejects a non-member", "app.[jt]s\n", "app.xs", false},
+		{"negated class rejects a member", "app.[!t]s\n", "app.ts", false},
+		{"negated class matches a non-member", "app.[!t]s\n", "app.js", true},
+		{"double star spans segments", "src/**/app.ts\n", "src/a/b/app.ts", true},
+		{"double star spans zero segments", "src/**/app.ts\n", "src/app.ts", true},
+		{"trailing double star matches everything below", "logs/**\n", "logs/a/b.txt", true},
+		{"leading double star matches at any depth", "**/gen.ts\n", "a/b/gen.ts", true},
+		{"excluding a directory excludes its contents", "build\n", "build/x/y.ts", true},
+		{"a similarly named directory is untouched", "build\n", "prebuild/x.ts", false},
+		{"negation re-includes a previously excluded file", "*.ts\n!keep.ts\n", "keep.ts", false},
+		{"order matters: re-exclude after negation", "*.ts\n!keep.ts\nkeep.ts\n", "keep.ts", true},
+		{"unclosed bracket is a literal", "a[b.ts\n", "a[b.ts", true},
+		{"invalid character class is skipped without panicking", "[z-a]\napp.ts\n", "app.ts", true},
+		{"invalid character class does not match its own line", "[z-a]\n", "z", false},
+		{"crlf line trims the carriage return before spaces", "foo \r\n", "foo", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ignore := compilePrettierIgnore([]byte(tc.ignore))
+
+			if got := ignore.ignores(tc.path); got != tc.excluded {
+				t.Fatalf("ignores(%q) = %v, want %v", tc.path, got, tc.excluded)
+			}
+		})
+	}
+}
+
+func TestLoadPrettierIgnoreAbsentFile(t *testing.T) {
+	ignore, err := loadPrettierIgnore(filepath.Join(t.TempDir(), ".prettierignore"))
+
+	if err != nil {
+		t.Fatalf("loadPrettierIgnore: %v", err)
+	}
+
+	if ignore != nil {
+		t.Fatalf("expected nil matcher for absent file, got %#v", ignore)
+	}
+}
+
+func TestCollectSurfacesUnreadablePrettierIgnore(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, "app.ts"), "const value = 1;\n")
+	gitAdd(t, dir, ".")
+
+	// A directory named .prettierignore is not IsNotExist, so the read error must
+	// surface rather than being swallowed.
+	if err := os.Mkdir(filepath.Join(dir, ".prettierignore"), 0o755); err != nil {
+		t.Fatalf("mkdir .prettierignore: %v", err)
+	}
+
+	if _, _, err := Collect(context.Background(), Options{Cwd: dir}); err == nil {
+		t.Fatal("expected an error from an unreadable .prettierignore")
+	}
+}
+
+func TestCollectHonorsPrettierIgnore(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, ".prettierignore"), "generated.ts\ndist/\n")
+	writeFile(t, filepath.Join(dir, "app.ts"), "const value = 1;\n")
+	writeFile(t, filepath.Join(dir, "generated.ts"), "const generated = 1;\n")
+	writeFile(t, filepath.Join(dir, "dist", "bundle.ts"), "const bundle = 1;\n")
+	gitAdd(t, dir, ".")
+
+	files, warnings, err := Collect(context.Background(), Options{Cwd: dir})
+
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+
+	want := []string{filepath.Join(dir, "app.ts")}
+
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("files mismatch\nwant: %#v\n got: %#v", want, files)
+	}
+}
+
+func TestCollectLintableHonorsPrettierIgnore(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, ".prettierignore"), "vendor/\n")
+	writeFile(t, filepath.Join(dir, "app.ts"), "const value = 1;\n")
+	writeFile(t, filepath.Join(dir, "vendor", "lib.ts"), "const lib = 1;\n")
+	gitAdd(t, dir, ".")
+
+	files, _, err := CollectLintable(context.Background(), Options{Cwd: dir})
+
+	if err != nil {
+		t.Fatalf("collect lintable: %v", err)
+	}
+
+	want := []string{filepath.Join(dir, "app.ts")}
+
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("files mismatch\nwant: %#v\n got: %#v", want, files)
+	}
+}
+
+func TestChangedPathsIgnoresPrettierIgnore(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, ".prettierignore"), "main.go\n")
+	writeFile(t, filepath.Join(dir, "main.go"), "package main\n")
+	gitAdd(t, dir, ".")
+
+	files, err := ChangedPaths(context.Background(), dir, nil)
+
+	if err != nil {
+		t.Fatalf("changed paths: %v", err)
+	}
+
+	// The Go lane must still see main.go even though .prettierignore lists it.
+	want := []string{
+		filepath.Join(dir, ".prettierignore"),
+		filepath.Join(dir, "main.go"),
+	}
+
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("files mismatch\nwant: %#v\n got: %#v", want, files)
+	}
+}

--- a/packages/go/driver/internal/sourcefiles/sourcefiles.go
+++ b/packages/go/driver/internal/sourcefiles/sourcefiles.go
@@ -61,7 +61,7 @@ func (s Selection) gitCommands(scope string) [][]string {
 // and Vue families plus the HTML and Markdown documents whose embedded scripts
 // get formatted.
 func Collect(ctx context.Context, opts Options) ([]string, []string, error) {
-	return collect(ctx, opts.Cwd, opts.Scopes, opts.Selection, func(path string) bool {
+	return collect(ctx, opts.Cwd, opts.Scopes, opts.Selection, true, func(path string) bool {
 		return isTargetFile(path, opts.IncludeDeclarations)
 	})
 }
@@ -70,7 +70,7 @@ func Collect(ctx context.Context, opts Options) ([]string, []string, error) {
 // the TS and Vue families. It is a subset of Collect — HTML and Markdown are
 // formattable but not lintable.
 func CollectLintable(ctx context.Context, opts Options) ([]string, []string, error) {
-	return collect(ctx, opts.Cwd, opts.Scopes, opts.Selection, func(path string) bool {
+	return collect(ctx, opts.Cwd, opts.Scopes, opts.Selection, true, func(path string) bool {
 		return isLintableFile(path, opts.IncludeDeclarations)
 	})
 }
@@ -79,15 +79,18 @@ func CollectLintable(ctx context.Context, opts Options) ([]string, []string, err
 // added — under the given scopes, whatever its extension. Callers do their own
 // filtering — the Go formatter, for one, has its own notion of which files it
 // owns.
+// ChangedPaths deliberately skips .prettierignore filtering: it feeds the Go
+// formatter, whose file set has nothing to do with Prettier's JS/TS ignore
+// list.
 func ChangedPaths(ctx context.Context, cwd string, scopes []string) ([]string, error) {
-	files, _, err := collect(ctx, cwd, scopes, SelectionChanged, func(string) bool {
+	files, _, err := collect(ctx, cwd, scopes, SelectionChanged, false, func(string) bool {
 		return true
 	})
 
 	return files, err
 }
 
-func collect(ctx context.Context, cwd string, scopes []string, selection Selection, keep func(string) bool) ([]string, []string, error) {
+func collect(ctx context.Context, cwd string, scopes []string, selection Selection, honorPrettierIgnore bool, keep func(string) bool) ([]string, []string, error) {
 	if strings.TrimSpace(cwd) == "" {
 		var err error
 
@@ -151,9 +154,54 @@ func collect(ctx context.Context, cwd string, scopes []string, selection Selecti
 		}
 	}
 
+	if honorPrettierIgnore {
+		kept, err := filterPrettierIgnored(cwd, files)
+
+		if err != nil {
+			return nil, warnings, err
+		}
+
+		files = kept
+	}
+
 	slices.Sort(files)
 
 	return files, warnings, nil
+}
+
+// filterPrettierIgnored drops any collected path the project's .prettierignore
+// excludes. Paths outside cwd are kept untouched: .prettierignore is anchored
+// to the directory that holds it and cannot speak to files above it.
+func filterPrettierIgnored(cwd string, files []string) ([]string, error) {
+	ignore, err := loadPrettierIgnore(filepath.Join(cwd, ".prettierignore"))
+
+	if err != nil {
+		return nil, err
+	}
+
+	if ignore == nil {
+		return files, nil
+	}
+
+	kept := make([]string, 0, len(files))
+
+	for _, path := range files {
+		rel, err := filepath.Rel(cwd, path)
+
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			kept = append(kept, path)
+
+			continue
+		}
+
+		if ignore.ignores(filepath.ToSlash(rel)) {
+			continue
+		}
+
+		kept = append(kept, path)
+	}
+
+	return kept, nil
 }
 
 func gitFiles(ctx context.Context, cwd, scope string, selection Selection) ([]string, error) {

--- a/packages/go/driver/internal/tsruntime/prettier.go
+++ b/packages/go/driver/internal/tsruntime/prettier.go
@@ -1,0 +1,215 @@
+package tsruntime
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// prettierConfigNames are the standalone Prettier configuration filenames, in
+// the order Prettier itself resolves them. package.json's "prettier" key is
+// checked separately, after these.
+var prettierConfigNames = []string{
+	".prettierrc",
+	".prettierrc.json",
+	".prettierrc.yml",
+	".prettierrc.yaml",
+	".prettierrc.json5",
+	".prettierrc.js",
+	".prettierrc.cjs",
+	".prettierrc.mjs",
+	".prettierrc.toml",
+	"prettier.config.js",
+	"prettier.config.cjs",
+	"prettier.config.mjs",
+}
+
+// detectPrettierConfig returns the path of the Prettier configuration cwd
+// carries, or "" when it has none. A standalone config file wins over
+// package.json's "prettier" key, matching Prettier's own precedence.
+func detectPrettierConfig(cwd string) string {
+	for _, name := range prettierConfigNames {
+		if path := existingFile(filepath.Join(cwd, name)); path != "" {
+			return path
+		}
+	}
+
+	packageJSON := filepath.Join(cwd, "package.json")
+
+	if existingFile(packageJSON) != "" && packageJSONHasPrettierKey(packageJSON) {
+		return packageJSON
+	}
+
+	return ""
+}
+
+// packageJSONHasPrettierKey reports whether package.json declares a top-level
+// "prettier" key set to anything other than null. Unreadable or invalid JSON
+// counts as absent.
+func packageJSONHasPrettierKey(path string) bool {
+	data, err := os.ReadFile(path)
+
+	if err != nil {
+		return false
+	}
+
+	var fields map[string]json.RawMessage
+
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return false
+	}
+
+	value, ok := fields["prettier"]
+
+	return ok && string(value) != "null"
+}
+
+// prettierDerivedConfig returns the path of an oxfmt config derived from cwd's
+// Prettier configuration, or "" when there is no Prettier config or the
+// migration fails. Failures print a one-line warning to stderr and leave the
+// caller to fall back to the bundled config; a translated config is cached by
+// the source config's content hash so migration runs at most once per config.
+func (s Support) prettierDerivedConfig(ctx context.Context, cwd string, env overrides, stderr io.Writer) string {
+	source := detectPrettierConfig(cwd)
+
+	if source == "" {
+		return ""
+	}
+
+	data, err := os.ReadFile(source)
+
+	if err != nil {
+		fmt.Fprintf(stderr, "[oxfmt] could not read Prettier config %s: %v; using bundled config\n", source, err)
+
+		return ""
+	}
+
+	sum := sha256.Sum256(data)
+	cachePath := filepath.Join(s.Dir, "prettier-derived", hex.EncodeToString(sum[:])+".json")
+
+	if existingFile(cachePath) != "" {
+		return cachePath
+	}
+
+	derived, err := s.migratePrettierConfig(ctx, source, env)
+
+	if err != nil {
+		fmt.Fprintf(stderr, "[oxfmt] could not derive oxfmt config from %s: %v; using bundled config\n", source, err)
+
+		return ""
+	}
+
+	if err := writeCacheFile(cachePath, derived); err != nil {
+		fmt.Fprintf(stderr, "[oxfmt] could not cache derived oxfmt config: %v; using bundled config\n", err)
+
+		return ""
+	}
+
+	return cachePath
+}
+
+// migratePrettierConfig copies the Prettier config into a private temp dir,
+// runs oxfmt --migrate=prettier there, and returns the resulting .oxfmtrc.json
+// bytes. The temp dir starts empty so the migrator never trips over a
+// pre-existing oxfmt config.
+func (s Support) migratePrettierConfig(ctx context.Context, source string, env overrides) ([]byte, error) {
+	dir, err := os.MkdirTemp("", "fmtkit-prettier-migrate-")
+
+	if err != nil {
+		return nil, fmt.Errorf("create migration dir: %w", err)
+	}
+
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	if err := copyFileContents(source, filepath.Join(dir, filepath.Base(source))); err != nil {
+		return nil, err
+	}
+
+	bin, args := s.migrateCommand(env)
+	args = append(args, "--migrate=prettier")
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = dir
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("oxfmt --migrate=prettier: %w", err)
+	}
+
+	derived, err := os.ReadFile(filepath.Join(dir, ".oxfmtrc.json"))
+
+	if err != nil {
+		return nil, fmt.Errorf("read migrated config: %w", err)
+	}
+
+	return derived, nil
+}
+
+// migrateCommand resolves the oxfmt invocation for a migration, mirroring
+// RunPipeline: an OXFMT_BIN override runs directly, otherwise the sidecar runs
+// in its oxfmt pass-through mode.
+func (s Support) migrateCommand(env overrides) (string, []string) {
+	if env.oxfmtBin != "" {
+		return env.oxfmtBin, nil
+	}
+
+	return s.Sidecar(), []string{"oxfmt"}
+}
+
+func copyFileContents(source, dst string) error {
+	data, err := os.ReadFile(source)
+
+	if err != nil {
+		return fmt.Errorf("read %s: %w", source, err)
+	}
+
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", dst, err)
+	}
+
+	return nil
+}
+
+// writeCacheFile writes data to path, creating parents and renaming a sibling
+// temp file into place so a hit never sees a half-written config.
+func writeCacheFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create cache dir: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-")
+
+	if err != nil {
+		return fmt.Errorf("create cache temp: %w", err)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+
+		return fmt.Errorf("write cache temp: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+
+		return fmt.Errorf("close cache temp: %w", err)
+	}
+
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		_ = os.Remove(tmp.Name())
+
+		return fmt.Errorf("activate cache file: %w", err)
+	}
+
+	return nil
+}

--- a/packages/go/driver/internal/tsruntime/prettier_internal_test.go
+++ b/packages/go/driver/internal/tsruntime/prettier_internal_test.go
@@ -1,0 +1,121 @@
+package tsruntime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMigrateCommandDefaultsToSidecar(t *testing.T) {
+	support := Support{Dir: filepath.Join("some", "dir")}
+
+	bin, args := support.migrateCommand(overrides{})
+
+	if bin != support.Sidecar() {
+		t.Fatalf("bin = %q, want sidecar %q", bin, support.Sidecar())
+	}
+
+	if len(args) != 1 || args[0] != "oxfmt" {
+		t.Fatalf("args = %q, want [oxfmt]", args)
+	}
+}
+
+func TestMigrateCommandHonorsOxfmtBin(t *testing.T) {
+	bin, args := Support{}.migrateCommand(overrides{oxfmtBin: "/usr/bin/oxfmt"})
+
+	if bin != "/usr/bin/oxfmt" || len(args) != 0 {
+		t.Fatalf("migrateCommand = (%q, %q), want (/usr/bin/oxfmt, [])", bin, args)
+	}
+}
+
+func TestCopyFileContentsReadError(t *testing.T) {
+	err := copyFileContents(filepath.Join(t.TempDir(), "missing"), filepath.Join(t.TempDir(), "dst"))
+
+	if err == nil {
+		t.Fatal("expected an error copying a missing source")
+	}
+}
+
+func TestWriteCacheFileMkdirError(t *testing.T) {
+	dir := t.TempDir()
+
+	blocker := filepath.Join(dir, "blocker")
+
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	// blocker is a file, so creating a directory beneath it must fail.
+	err := writeCacheFile(filepath.Join(blocker, "sub", "cfg.json"), []byte("{}"))
+
+	if err == nil {
+		t.Fatal("expected an error when the cache parent cannot be created")
+	}
+}
+
+func TestPackageJSONHasPrettierKeyMissingFile(t *testing.T) {
+	if packageJSONHasPrettierKey(filepath.Join(t.TempDir(), "package.json")) {
+		t.Fatal("a missing package.json cannot carry a prettier key")
+	}
+}
+
+func TestPrettierDerivedConfigWarnsWhenCacheWriteFails(t *testing.T) {
+	support := supportWithStub(t)
+
+	oxfmt := filepath.Join(t.TempDir(), "oxfmt")
+	writeMigrateStub(t, oxfmt)
+
+	// Occupy the cache directory path with a regular file so MkdirAll fails.
+	if err := os.WriteFile(filepath.Join(support.Dir, "prettier-derived"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write cache blocker: %v", err)
+	}
+
+	cwd := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(cwd, ".prettierrc.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write prettier config: %v", err)
+	}
+
+	env := overrides{oxfmtBin: oxfmt}
+
+	var stderr strings.Builder
+
+	if got := support.prettierDerivedConfig(context.Background(), cwd, env, &stderr); got != "" {
+		t.Fatalf("expected empty result on cache failure, got %q", got)
+	}
+
+	if !strings.Contains(stderr.String(), "could not cache") {
+		t.Fatalf("expected a cache warning, got %q", stderr.String())
+	}
+}
+
+func TestPrettierDerivedConfigWarnsWhenMigrationWritesNoConfig(t *testing.T) {
+	support := supportWithStub(t)
+
+	// A stub that exits 0 but writes no .oxfmtrc.json: the read-back must fail.
+	silent := filepath.Join(t.TempDir(), "oxfmt")
+
+	if err := os.WriteFile(silent, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write silent stub: %v", err)
+	}
+
+	cwd := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(cwd, ".prettierrc.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write prettier config: %v", err)
+	}
+
+	var stderr strings.Builder
+
+	got := support.prettierDerivedConfig(context.Background(), cwd, overrides{oxfmtBin: silent}, &stderr)
+
+	if got != "" {
+		t.Fatalf("expected empty result when no config is produced, got %q", got)
+	}
+
+	if !strings.Contains(stderr.String(), "could not derive") {
+		t.Fatalf("expected a derive warning, got %q", stderr.String())
+	}
+}

--- a/packages/go/driver/internal/tsruntime/prettier_test.go
+++ b/packages/go/driver/internal/tsruntime/prettier_test.go
@@ -1,0 +1,356 @@
+package tsruntime
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeMigrateStub creates a fake oxfmt that, on --migrate=prettier, writes an
+// .oxfmtrc.json into its working directory carrying a marker so tests can prove
+// migration ran. It counts invocations in a sibling file so cache hits are
+// observable.
+func writeMigrateStub(t *testing.T, path string) {
+	t.Helper()
+
+	counter := filepath.Join(filepath.Dir(path), "migrate-count")
+
+	script := "#!/bin/sh\n" +
+		"printf 'x' >> '" + counter + "'\n" +
+		"echo '{\"derived\":true}' > \"$PWD/.oxfmtrc.json\"\n"
+
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write migrate stub %s: %v", path, err)
+	}
+}
+
+func migrateInvocations(t *testing.T, stubDir string) int {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(stubDir, "migrate-count"))
+
+	if os.IsNotExist(err) {
+		return 0
+	}
+
+	if err != nil {
+		t.Fatalf("read migrate count: %v", err)
+	}
+
+	return len(data)
+}
+
+func TestDetectPrettierConfigFilenames(t *testing.T) {
+	names := []string{
+		".prettierrc",
+		".prettierrc.json",
+		".prettierrc.yml",
+		".prettierrc.yaml",
+		".prettierrc.json5",
+		".prettierrc.js",
+		".prettierrc.cjs",
+		".prettierrc.mjs",
+		".prettierrc.toml",
+		"prettier.config.js",
+		"prettier.config.cjs",
+		"prettier.config.mjs",
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			path := filepath.Join(dir, name)
+
+			if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+				t.Fatalf("write %s: %v", name, err)
+			}
+
+			if got := detectPrettierConfig(dir); got != path {
+				t.Fatalf("detectPrettierConfig = %q, want %q", got, path)
+			}
+		})
+	}
+}
+
+func TestDetectPrettierConfigNone(t *testing.T) {
+	if got := detectPrettierConfig(t.TempDir()); got != "" {
+		t.Fatalf("detectPrettierConfig = %q, want empty", got)
+	}
+}
+
+func TestDetectPrettierConfigPackageJSON(t *testing.T) {
+	cases := []struct {
+		name     string
+		contents string
+		want     bool
+	}{
+		{"key present", `{"prettier":{"semi":false}}`, true},
+		{"key set to a string path", `{"prettier":"./cfg.json"}`, true},
+		{"key null does not count", `{"prettier":null}`, false},
+		{"key absent", `{"name":"pkg"}`, false},
+		{"invalid json", `{`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			path := filepath.Join(dir, "package.json")
+
+			if err := os.WriteFile(path, []byte(tc.contents), 0o644); err != nil {
+				t.Fatalf("write package.json: %v", err)
+			}
+
+			got := detectPrettierConfig(dir)
+
+			if tc.want && got != path {
+				t.Fatalf("detectPrettierConfig = %q, want %q", got, path)
+			}
+
+			if !tc.want && got != "" {
+				t.Fatalf("detectPrettierConfig = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestDetectPrettierConfigPrefersStandaloneOverPackageJSON(t *testing.T) {
+	dir := t.TempDir()
+
+	standalone := filepath.Join(dir, ".prettierrc.json")
+
+	if err := os.WriteFile(standalone, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write .prettierrc.json: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"prettier":{}}`), 0o644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+
+	if got := detectPrettierConfig(dir); got != standalone {
+		t.Fatalf("detectPrettierConfig = %q, want %q", got, standalone)
+	}
+}
+
+func TestOxfmtConfigForDerivesFromPrettier(t *testing.T) {
+	support := supportWithStub(t)
+
+	if err := os.WriteFile(filepath.Join(support.Dir, ".oxfmtrc.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write bundled config: %v", err)
+	}
+
+	oxfmt := filepath.Join(t.TempDir(), "oxfmt")
+	writeMigrateStub(t, oxfmt)
+
+	cwd := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(cwd, ".prettierrc.json"), []byte(`{"semi":false}`), 0o644); err != nil {
+		t.Fatalf("write prettier config: %v", err)
+	}
+
+	t.Setenv(OxfmtBinEnv, oxfmt)
+
+	env := readOverrides()
+
+	var stderr bytes.Buffer
+
+	config := support.oxfmtConfigFor(context.Background(), cwd, env, &stderr)
+
+	if config == "" || existingFile(config) == "" {
+		t.Fatalf("expected a derived config path, got %q (stderr: %s)", config, stderr.String())
+	}
+
+	data, err := os.ReadFile(config)
+
+	if err != nil {
+		t.Fatalf("read derived config: %v", err)
+	}
+
+	if !strings.Contains(string(data), "derived") {
+		t.Fatalf("derived config = %q, want migrated marker", data)
+	}
+
+	if !strings.HasPrefix(config, filepath.Join(support.Dir, "prettier-derived")) {
+		t.Fatalf("derived config %q not under the support cache", config)
+	}
+}
+
+func TestOxfmtConfigForCachesDerivedConfig(t *testing.T) {
+	support := supportWithStub(t)
+
+	oxfmt := filepath.Join(t.TempDir(), "oxfmt")
+	writeMigrateStub(t, oxfmt)
+
+	cwd := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(cwd, ".prettierrc.json"), []byte(`{"semi":false}`), 0o644); err != nil {
+		t.Fatalf("write prettier config: %v", err)
+	}
+
+	t.Setenv(OxfmtBinEnv, oxfmt)
+
+	env := readOverrides()
+
+	var stderr bytes.Buffer
+
+	first := support.oxfmtConfigFor(context.Background(), cwd, env, &stderr)
+	second := support.oxfmtConfigFor(context.Background(), cwd, env, &stderr)
+
+	if first != second {
+		t.Fatalf("cache miss on second call: %q vs %q", first, second)
+	}
+
+	if got := migrateInvocations(t, filepath.Dir(oxfmt)); got != 1 {
+		t.Fatalf("migration ran %d times, want 1 (cache hit expected)", got)
+	}
+}
+
+func TestOxfmtConfigForRemigratesWhenConfigChanges(t *testing.T) {
+	support := supportWithStub(t)
+
+	oxfmt := filepath.Join(t.TempDir(), "oxfmt")
+	writeMigrateStub(t, oxfmt)
+
+	cwd := t.TempDir()
+
+	prettier := filepath.Join(cwd, ".prettierrc.json")
+
+	if err := os.WriteFile(prettier, []byte(`{"semi":false}`), 0o644); err != nil {
+		t.Fatalf("write prettier config: %v", err)
+	}
+
+	t.Setenv(OxfmtBinEnv, oxfmt)
+
+	env := readOverrides()
+
+	var stderr bytes.Buffer
+
+	support.oxfmtConfigFor(context.Background(), cwd, env, &stderr)
+
+	if err := os.WriteFile(prettier, []byte(`{"semi":true}`), 0o644); err != nil {
+		t.Fatalf("rewrite prettier config: %v", err)
+	}
+
+	support.oxfmtConfigFor(context.Background(), cwd, env, &stderr)
+
+	if got := migrateInvocations(t, filepath.Dir(oxfmt)); got != 2 {
+		t.Fatalf("migration ran %d times, want 2 (content hash should change)", got)
+	}
+}
+
+func TestOxfmtConfigForPrecedence(t *testing.T) {
+	support := supportWithStub(t)
+
+	if err := os.WriteFile(filepath.Join(support.Dir, ".oxfmtrc.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write bundled config: %v", err)
+	}
+
+	oxfmt := filepath.Join(t.TempDir(), "oxfmt")
+	writeMigrateStub(t, oxfmt)
+
+	t.Setenv(OxfmtBinEnv, oxfmt)
+
+	t.Run("project .oxfmtrc beats prettier", func(t *testing.T) {
+		cwd := t.TempDir()
+
+		if err := os.WriteFile(filepath.Join(cwd, ".oxfmtrc.json"), []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write project config: %v", err)
+		}
+
+		if err := os.WriteFile(filepath.Join(cwd, ".prettierrc.json"), []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write prettier config: %v", err)
+		}
+
+		var stderr bytes.Buffer
+
+		if got := support.oxfmtConfigFor(context.Background(), cwd, readOverrides(), &stderr); got != "" {
+			t.Fatalf("expected auto-discovery signal for project config, got %q", got)
+		}
+	})
+
+	t.Run("prettier beats bundled", func(t *testing.T) {
+		cwd := t.TempDir()
+
+		if err := os.WriteFile(filepath.Join(cwd, ".prettierrc.json"), []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write prettier config: %v", err)
+		}
+
+		var stderr bytes.Buffer
+
+		got := support.oxfmtConfigFor(context.Background(), cwd, readOverrides(), &stderr)
+
+		if !strings.HasPrefix(got, filepath.Join(support.Dir, "prettier-derived")) {
+			t.Fatalf("expected derived config, got %q", got)
+		}
+	})
+
+	t.Run("bundled when neither present", func(t *testing.T) {
+		cwd := t.TempDir()
+
+		var stderr bytes.Buffer
+
+		if got := support.oxfmtConfigFor(context.Background(), cwd, readOverrides(), &stderr); got != support.OxfmtConfig() {
+			t.Fatalf("expected bundled config %q, got %q", support.OxfmtConfig(), got)
+		}
+	})
+
+	t.Run("env override beats all", func(t *testing.T) {
+		cwd := t.TempDir()
+
+		if err := os.WriteFile(filepath.Join(cwd, ".prettierrc.json"), []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write prettier config: %v", err)
+		}
+
+		override := filepath.Join(t.TempDir(), "custom.json")
+
+		if err := os.WriteFile(override, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write override config: %v", err)
+		}
+
+		env := readOverrides()
+		env.oxfmtConfig = override
+
+		if got := support.oxfmtConfigFor(context.Background(), cwd, env, &bytes.Buffer{}); got != override {
+			t.Fatalf("expected override %q, got %q", override, got)
+		}
+	})
+}
+
+func TestOxfmtConfigForFallsBackWhenMigrationFails(t *testing.T) {
+	support := supportWithStub(t)
+
+	if err := os.WriteFile(filepath.Join(support.Dir, ".oxfmtrc.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write bundled config: %v", err)
+	}
+
+	// A stub that exits nonzero and writes no config is the JS-config failure case.
+	failing := filepath.Join(t.TempDir(), "oxfmt")
+
+	if err := os.WriteFile(failing, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write failing stub: %v", err)
+	}
+
+	cwd := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(cwd, ".prettierrc.js"), []byte("module.exports = {};\n"), 0o644); err != nil {
+		t.Fatalf("write prettier config: %v", err)
+	}
+
+	t.Setenv(OxfmtBinEnv, failing)
+
+	var stderr bytes.Buffer
+
+	got := support.oxfmtConfigFor(context.Background(), cwd, readOverrides(), &stderr)
+
+	if got != support.OxfmtConfig() {
+		t.Fatalf("expected bundled fallback %q, got %q", support.OxfmtConfig(), got)
+	}
+
+	if !strings.Contains(stderr.String(), "using bundled config") {
+		t.Fatalf("expected a warning on stderr, got %q", stderr.String())
+	}
+}

--- a/packages/go/driver/internal/tsruntime/run.go
+++ b/packages/go/driver/internal/tsruntime/run.go
@@ -98,7 +98,7 @@ func (s Support) RunPipeline(ctx context.Context, opts RunOptions) error {
 		args = append(args, "--oxfmt-bin", s.Sidecar())
 	}
 
-	if config := s.oxfmtConfigFor(cwd, env); config != "" {
+	if config := s.oxfmtConfigFor(ctx, cwd, env, opts.Stderr); config != "" {
 		args = append(args, "--oxfmt-config", config)
 	}
 
@@ -199,16 +199,21 @@ func collectLintable(ctx context.Context, cwd string, scopes []string, includeDe
 	})
 }
 
-// oxfmtConfigFor mirrors the entrypoint rule: a project-local .oxfmtrc.*
-// wins via oxfmt's own auto-discovery, otherwise fall back to the bundled
-// configuration.
-func (s Support) oxfmtConfigFor(cwd string, env overrides) string {
+// oxfmtConfigFor resolves the oxfmt config by precedence: the FMTKIT_OXFMTRC
+// override, then a project-local .oxfmtrc.* (via oxfmt's own auto-discovery,
+// signalled by ""), then a config derived from the project's Prettier
+// configuration, and finally the bundled default.
+func (s Support) oxfmtConfigFor(ctx context.Context, cwd string, env overrides, stderr io.Writer) string {
 	if env.oxfmtConfig != "" {
 		return existingFile(env.oxfmtConfig)
 	}
 
 	if matches, err := filepath.Glob(filepath.Join(cwd, ".oxfmtrc.*")); err == nil && len(matches) > 0 {
 		return ""
+	}
+
+	if derived := s.prettierDerivedConfig(ctx, cwd, env, stderr); derived != "" {
+		return derived
 	}
 
 	return s.OxfmtConfig()


### PR DESCRIPTION
Stacked on #61.

Projects with a Prettier config but no `.oxfmtrc` now Just Work: fmtkit translates the Prettier config via oxfmt's built-in `--migrate=prettier` and honors `.prettierignore` across the whole TS pipeline.

## Config resolution

New precedence in `tsruntime` (first match wins):

1. `FMTKIT_OXFMTRC`
2. A project-local `.oxfmtrc.*` (oxfmt auto-discovery, unchanged)
3. **Prettier-derived**: a detected `.prettierrc*`, `prettier.config.*`, or `package.json` `"prettier"` key is copied to a private temp dir, migrated with `oxfmt --migrate=prettier`, and the result passed via `--oxfmt-config`. Cached under the support dir by the source config's content hash, so migration runs once per config change. Any failure (e.g. a JS config importing project modules) warns on stderr and falls back — it never fails the run.
4. The bundled default

Detection is done by fmtkit itself because the migrator writes a default config with exit 0 when no Prettier config exists.

## .prettierignore

oxfmt already honors `.prettierignore` (verified, even for explicitly passed paths) — but the custom passes (blank-lines, fluent-chains) and `oxlint --fix` operate on the Go-collected file list and did not. A dependency-free gitignore-syntax matcher (`sourcefiles/prettierignore.go`) now filters `Collect`/`CollectLintable`, so an ignored file is untouched by every lane. `ChangedPaths` deliberately skips the filter: it feeds the Go formatter. Supported syntax: comments, negation (last match wins), leading-`/` anchoring, trailing-`/` directory patterns, `*`, `?`, `[...]`, `**`; unparseable lines are skipped rather than crashing.

## Verification

- `go test ./...` green, `go vet` clean; gated Go coverage 85.8% (gate ≥ 85).
- Unit tests cover every config filename form, precedence order, cache hit/miss/staleness, failure fallback, and 27 table-driven matcher cases.
- End-to-end with the real dev binary on a scratch project (`"semi": false` + `.prettierignore`): output formatted semicolon-free/single-quoted proving the derived config applied, the ignored file byte-for-byte untouched by all passes, cache materialized.
- README documents the precedence chain and ignore behavior.