### PR TITLE
refactor(go): G2 — spacing analyzers share parse state

### DIFF
--- a/packages/go/formatter/rules/spacing/context.go
+++ b/packages/go/formatter/rules/spacing/context.go
@@ -1,0 +1,67 @@
+package spacing
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+)
+
+// importAliases maps the identifier a file uses to the standard-library import
+// path it refers to, restricted to the packages whose selector calls the
+// spacing rule brackets with blank lines.
+type importAliases map[string]string
+
+// fileContext holds the parse state a spacing pass shares: the file is parsed
+// once and the derived line-start and import-alias tables are built alongside it
+// so every analyzer reads the same view of the source.
+type fileContext struct {
+	fset       *token.FileSet
+	file       *ast.File
+	src        []byte
+	lineStarts []int
+	aliases    importAliases
+}
+
+// stdlibSpacingImports returns the standard-library import paths whose selector
+// calls receive blank-line spacing, keyed to the identifier each import binds by
+// default. It replaces a package-level map so the table cannot be mutated at run
+// time and is rebuilt fresh for every file.
+func stdlibSpacingImports() map[string]string {
+	return map[string]string{
+		"sort":         "sort",
+		"slices":       "slices",
+		"math/rand":    "rand",
+		"math/rand/v2": "rand",
+	}
+}
+
+// newFileContext parses src and precomputes the shared line-start and
+// import-alias tables. It returns an error when the source cannot be parsed or
+// the parsed file has no backing token file.
+func newFileContext(filename string, src []byte) (*fileContext, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, src, parser.ParseComments)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if fset.File(file.Pos()) == nil {
+		return nil, fmt.Errorf("missing token file for %s", filename)
+	}
+
+	return &fileContext{
+		fset:       fset,
+		file:       file,
+		src:        src,
+		lineStarts: buildLineStarts(src),
+		aliases:    buildImportAliases(file),
+	}, nil
+}
+
+// lineStartOffset returns the byte offset at which the given 1-based line begins,
+// using the precomputed line-start table.
+func (c *fileContext) lineStartOffset(line int) int {
+	return lineStartOffset(c.lineStarts, line)
+}

--- a/packages/go/formatter/rules/spacing/embeds.go
+++ b/packages/go/formatter/rules/spacing/embeds.go
@@ -11,6 +11,17 @@ import (
 	"go.ollin.sh/fmtkit/formatter/rules"
 )
 
+// embedDirectiveRepairer keeps go:embed directives immediately above the var
+// declaration they annotate, reading the shared parse state through ctx.
+type embedDirectiveRepairer struct {
+	ctx *fileContext
+}
+
+// newEmbedDirectiveRepairer returns a repairer bound to the shared parse state.
+func newEmbedDirectiveRepairer(ctx *fileContext) *embedDirectiveRepairer {
+	return &embedDirectiveRepairer{ctx: ctx}
+}
+
 func attachEmbedDirectiveDocs(file *ast.File) {
 	for decl, group := range embedDirectiveMatches(file) {
 		genDecl, ok := decl.(*ast.GenDecl)
@@ -23,12 +34,14 @@ func attachEmbedDirectiveDocs(file *ast.File) {
 	}
 }
 
-func embedAdjacencyViolations(file *ast.File, fset *token.FileSet, filename string) []rules.Violation {
+// analyze reports every go:embed directive separated from the var declaration it
+// annotates, labelling the returned violations with filename.
+func (e *embedDirectiveRepairer) analyze(filename string) []rules.Violation {
 	var violations []rules.Violation
 
-	for decl, group := range embedDirectiveMatches(file) {
-		commentEndLine := fset.Position(group.End()).Line
-		declLine := fset.Position(decl.Pos()).Line
+	for decl, group := range embedDirectiveMatches(e.ctx.file) {
+		commentEndLine := e.ctx.fset.Position(group.End()).Line
+		declLine := e.ctx.fset.Position(decl.Pos()).Line
 
 		if declLine == commentEndLine+1 {
 			continue
@@ -45,7 +58,11 @@ func embedAdjacencyViolations(file *ast.File, fset *token.FileSet, filename stri
 	return violations
 }
 
-func repairDetachedEmbedDirectives(filename string, src []byte) ([]byte, error) {
+// repair re-parses src — which may already carry the type reorder — and moves
+// every detached go:embed directive group back immediately above its var
+// declaration. It parses its own file rather than reusing ctx because it operates
+// on the transformed bytes.
+func (e *embedDirectiveRepairer) repair(filename string, src []byte) ([]byte, error) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, filename, src, parser.ParseComments)
 
@@ -193,6 +210,9 @@ func containsEmbedDirective(group *ast.CommentGroup) bool {
 	return false
 }
 
+// collapseEmbedSpacing removes a single blank line left between a go:embed
+// directive and the var declaration it annotates. It works purely on bytes with
+// no parse state, so it stays a free function the repairer's collapse step calls.
 func collapseEmbedSpacing(src []byte) []byte {
 	lines := bytes.Split(src, []byte{'\n'})
 	out := make([][]byte, 0, len(lines))

--- a/packages/go/formatter/rules/spacing/gaps.go
+++ b/packages/go/formatter/rules/spacing/gaps.go
@@ -8,46 +8,114 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+
+	"go.ollin.sh/fmtkit/formatter/rules"
 )
 
-type importAliases map[string]string
-
-var stdlibSpacingImports = map[string]string{
-	"sort":         "sort",
-	"slices":       "slices",
-	"math/rand":    "rand",
-	"math/rand/v2": "rand",
+// blankLineInserter records the blank lines the spacing rule must add between
+// statements and top-level declarations, then applies them to the source. It
+// reads the shared parse state through ctx and accumulates the byte offsets to
+// split in insertions.
+type blankLineInserter struct {
+	ctx        *fileContext
+	insertions map[int]struct{}
 }
 
-func setupSpacingLine(list []ast.Stmt, index int, current ast.Stmt, next ast.Stmt, aliases importAliases, fset *token.FileSet) (int, bool) {
-	if index == 0 {
-		return 0, false
+// newBlankLineInserter returns an inserter bound to the shared parse state.
+func newBlankLineInserter(ctx *fileContext) *blankLineInserter {
+	return &blankLineInserter{
+		ctx:        ctx,
+		insertions: map[int]struct{}{},
 	}
-
-	receiverName, ok := selectorReceiverName(next, aliases)
-
-	if !ok {
-		return 0, false
-	}
-
-	assignedName, ok := assignedIdentifier(current)
-
-	if !ok || assignedName != receiverName {
-		return 0, false
-	}
-
-	currentLine := fset.Position(current.Pos()).Line
-	prevEndLine := fset.Position(list[index-1].End()).Line
-
-	if currentLine >= prevEndLine+2 {
-		return 0, false
-	}
-
-	return currentLine, true
 }
 
-func inspectStmtLists(file *ast.File, visit func([]ast.Stmt)) {
-	ast.Inspect(file, func(node ast.Node) bool {
+// analyze walks the file's statement lists and top-level declarations, recording
+// a violation and an insertion offset for every missing blank line. filename
+// labels the returned violations.
+func (b *blankLineInserter) analyze(filename string) []rules.Violation {
+	fset := b.ctx.fset
+
+	var violations []rules.Violation
+
+	b.inspectStmtLists(func(list []ast.Stmt) {
+		for i := 0; i < len(list)-1; i++ {
+			current := list[i]
+			next := list[i+1]
+			endLine := fset.Position(current.End()).Line
+			nextLine := fset.Position(next.Pos()).Line
+
+			if currentLine, ok := b.setupSpacingLine(list, i, current, next); ok {
+				violations = append(violations, rules.Violation{
+					Rule:    "spacing",
+					File:    filename,
+					Line:    currentLine,
+					Message: "missing blank line before selector call setup",
+				})
+
+				b.insertions[b.ctx.lineStartOffset(currentLine)] = struct{}{}
+			}
+
+			if endLine == nextLine {
+				continue
+			}
+
+			if message, ok := b.statementGapRule(current, next); ok {
+				if nextLine < endLine+2 {
+					violations = append(violations, rules.Violation{
+						Rule:    "spacing",
+						File:    filename,
+						Line:    nextLine,
+						Message: message,
+					})
+
+					b.insertions[b.ctx.lineStartOffset(nextLine)] = struct{}{}
+				}
+			}
+		}
+	})
+
+	for i := 0; i < len(b.ctx.file.Decls)-1; i++ {
+		current := b.ctx.file.Decls[i]
+		next := b.ctx.file.Decls[i+1]
+
+		if !requiresTypeDeclSpacing(current, next) {
+			continue
+		}
+
+		endLine := fset.Position(current.End()).Line
+		nextLine := fset.Position(next.Pos()).Line
+
+		if nextLine >= endLine+2 {
+			continue
+		}
+
+		violations = append(violations, rules.Violation{
+			Rule:    "spacing",
+			File:    filename,
+			Line:    nextLine,
+			Message: "missing blank line around type definition",
+		})
+
+		b.insertions[b.ctx.lineStartOffset(nextLine)] = struct{}{}
+	}
+
+	return violations
+}
+
+// apply returns the source with the recorded blank-line insertions applied, or
+// the source unchanged when the analysis recorded none.
+func (b *blankLineInserter) apply() []byte {
+	if len(b.insertions) == 0 {
+		return b.ctx.src
+	}
+
+	return applyInsertions(b.ctx.src, b.insertions)
+}
+
+// inspectStmtLists visits every statement list in the file: block bodies, case
+// clause bodies, and communication clause bodies.
+func (b *blankLineInserter) inspectStmtLists(visit func([]ast.Stmt)) {
+	ast.Inspect(b.ctx.file, func(node ast.Node) bool {
 		switch typed := node.(type) {
 		case *ast.BlockStmt:
 			visit(typed.List)
@@ -61,42 +129,77 @@ func inspectStmtLists(file *ast.File, visit func([]ast.Stmt)) {
 	})
 }
 
-func statementGapRule(current ast.Stmt, next ast.Stmt, aliases importAliases, fset *token.FileSet) (string, bool) {
-	if label, ok := requiresLeadingBlankLine(next, aliases); ok {
+// setupSpacingLine reports the line that needs a leading blank line when the
+// current statement assigns the receiver of a following spaced selector call and
+// the two sit flush against the preceding statement.
+func (b *blankLineInserter) setupSpacingLine(list []ast.Stmt, index int, current ast.Stmt, next ast.Stmt) (int, bool) {
+	if index == 0 {
+		return 0, false
+	}
+
+	receiverName, ok := selectorReceiverName(next, b.ctx.aliases)
+
+	if !ok {
+		return 0, false
+	}
+
+	assignedName, ok := assignedIdentifier(current)
+
+	if !ok || assignedName != receiverName {
+		return 0, false
+	}
+
+	currentLine := b.ctx.fset.Position(current.Pos()).Line
+	prevEndLine := b.ctx.fset.Position(list[index-1].End()).Line
+
+	if currentLine >= prevEndLine+2 {
+		return 0, false
+	}
+
+	return currentLine, true
+}
+
+// statementGapRule reports the message for a missing blank line between current
+// and next, checking the leading rule for next before the trailing rule for
+// current.
+func (b *blankLineInserter) statementGapRule(current ast.Stmt, next ast.Stmt) (string, bool) {
+	if label, ok := b.requiresLeadingBlankLine(next); ok {
 		return fmt.Sprintf("missing blank line before %s", label), true
 	}
 
-	if label, ok := requiresTrailingBlankLine(current, next, aliases, fset); ok {
+	if label, ok := b.requiresTrailingBlankLine(current, next); ok {
 		return fmt.Sprintf("missing blank line after %s", label), true
 	}
 
 	return "", false
 }
 
-func requiresTrailingBlankLine(current ast.Stmt, next ast.Stmt, aliases importAliases, fset *token.FileSet) (string, bool) {
+// requiresTrailingBlankLine reports whether current must be followed by a blank
+// line, returning the label used in the violation message.
+func (b *blankLineInserter) requiresTrailingBlankLine(current ast.Stmt, next ast.Stmt) (string, bool) {
 	if isTestingHelperCall(current) {
 		return "t.Helper call", true
 	}
 
-	if isAnonymousFuncAssignmentStmt(current, fset) {
+	if isAnonymousFuncAssignmentStmt(current, b.ctx.fset) {
 		return "anonymous function assignment", true
 	}
 
-	if label, ok := stdlibSpacedCallLabel(current, aliases); ok {
+	if label, ok := stdlibSpacedCallLabel(current, b.ctx.aliases); ok {
 		return label, true
 	}
 
 	switch current.(type) {
 	case *ast.IfStmt, *ast.ForStmt, *ast.RangeStmt, *ast.SwitchStmt, *ast.TypeSwitchStmt, *ast.SelectStmt, *ast.DeferStmt, *ast.BranchStmt:
-		return statementLabel(current, aliases), true
+		return statementLabel(current, b.ctx.aliases), true
 	case *ast.DeclStmt:
 		if isTypeDeclStmt(current) {
-			return statementLabel(current, aliases), true
+			return statementLabel(current, b.ctx.aliases), true
 		}
 
 		if isVarDeclStmt(current) {
 			if !isShortAssignStmt(next) && !isVarDeclStmt(next) {
-				return statementLabel(current, aliases), true
+				return statementLabel(current, b.ctx.aliases), true
 			}
 		}
 	}
@@ -104,21 +207,23 @@ func requiresTrailingBlankLine(current ast.Stmt, next ast.Stmt, aliases importAl
 	return "", false
 }
 
-func requiresLeadingBlankLine(stmt ast.Stmt, aliases importAliases) (string, bool) {
+// requiresLeadingBlankLine reports whether stmt must be preceded by a blank
+// line, returning the label used in the violation message.
+func (b *blankLineInserter) requiresLeadingBlankLine(stmt ast.Stmt) (string, bool) {
 	if label, ok := routeRegistryCallLabel(stmt); ok {
 		return label, true
 	}
 
-	if label, ok := stdlibSpacedCallLabel(stmt, aliases); ok {
+	if label, ok := stdlibSpacedCallLabel(stmt, b.ctx.aliases); ok {
 		return label, true
 	}
 
 	switch stmt.(type) {
 	case *ast.IfStmt, *ast.ForStmt, *ast.RangeStmt, *ast.SwitchStmt, *ast.TypeSwitchStmt, *ast.SelectStmt, *ast.DeferStmt, *ast.ReturnStmt, *ast.BranchStmt:
-		return statementLabel(stmt, aliases), true
+		return statementLabel(stmt, b.ctx.aliases), true
 	case *ast.DeclStmt:
 		if isTypeDeclStmt(stmt) || isVarDeclStmt(stmt) {
-			return statementLabel(stmt, aliases), true
+			return statementLabel(stmt, b.ctx.aliases), true
 		}
 	}
 
@@ -197,6 +302,7 @@ func statementLabel(stmt ast.Stmt, aliases importAliases) string {
 
 func buildImportAliases(file *ast.File) importAliases {
 	aliases := make(importAliases)
+	stdlib := stdlibSpacingImports()
 
 	for _, spec := range file.Imports {
 		path, err := strconv.Unquote(spec.Path.Value)
@@ -205,7 +311,7 @@ func buildImportAliases(file *ast.File) importAliases {
 			continue
 		}
 
-		defaultName, ok := stdlibSpacingImports[path]
+		defaultName, ok := stdlib[path]
 
 		if !ok {
 			continue

--- a/packages/go/formatter/rules/spacing/spacing.go
+++ b/packages/go/formatter/rules/spacing/spacing.go
@@ -1,11 +1,6 @@
 package spacing
 
 import (
-	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
-
 	"go.ollin.sh/fmtkit/formatter/rules"
 )
 
@@ -22,106 +17,33 @@ func (Rule) Name() string {
 	return "spacing"
 }
 
+// Apply parses the source once into a shared fileContext, then runs the three
+// spacing analyzers over it in a fixed order: the blank-line inserter, the
+// type-order rewriter, and the embed-directive repairer. Analysis collects every
+// violation up front; the rewrite phase only runs when at least one violation
+// was reported, and preserves the current sequencing of insertions, type
+// reordering, embed repair, and embed collapse.
 func (r Rule) Apply(path string, src []byte) ([]rules.Violation, []byte, error) {
-	return analyse(path, src)
-}
-
-func analyse(filename string, src []byte) ([]rules.Violation, []byte, error) {
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, filename, src, parser.ParseComments)
+	ctx, err := newFileContext(path, src)
 
 	if err != nil {
 		return nil, nil, err
 	}
 
-	tokenFile := fset.File(file.Pos())
-
-	if tokenFile == nil {
-		return nil, nil, fmt.Errorf("missing token file for %s", filename)
-	}
-
-	lineStarts := buildLineStarts(src)
-	insertions := map[int]struct{}{}
-	aliases := buildImportAliases(file)
+	inserter := newBlankLineInserter(ctx)
+	typeOrder := newTypeOrderRewriter(ctx)
+	embeds := newEmbedDirectiveRepairer(ctx)
 
 	var violations []rules.Violation
 
-	inspectStmtLists(file, func(list []ast.Stmt) {
-		for i := 0; i < len(list)-1; i++ {
-			current := list[i]
-			next := list[i+1]
-			endLine := fset.Position(current.End()).Line
-			nextLine := fset.Position(next.Pos()).Line
+	violations = append(violations, inserter.analyze(path)...)
+	violations = append(violations, typeOrder.analyze(path)...)
+	violations = append(violations, embeds.analyze(path)...)
 
-			if currentLine, ok := setupSpacingLine(list, i, current, next, aliases, fset); ok {
-				violations = append(violations, rules.Violation{
-					Rule:    "spacing",
-					File:    filename,
-					Line:    currentLine,
-					Message: "missing blank line before selector call setup",
-				})
-
-				offset := lineStartOffset(lineStarts, currentLine)
-				insertions[offset] = struct{}{}
-			}
-
-			if endLine == nextLine {
-				continue
-			}
-
-			if message, ok := statementGapRule(current, next, aliases, fset); ok {
-				if nextLine < endLine+2 {
-					violations = append(violations, rules.Violation{
-						Rule:    "spacing",
-						File:    filename,
-						Line:    nextLine,
-						Message: message,
-					})
-
-					offset := lineStartOffset(lineStarts, nextLine)
-					insertions[offset] = struct{}{}
-				}
-			}
-		}
-	})
-
-	for i := 0; i < len(file.Decls)-1; i++ {
-		current := file.Decls[i]
-		next := file.Decls[i+1]
-
-		if !requiresTypeDeclSpacing(current, next) {
-			continue
-		}
-
-		endLine := fset.Position(current.End()).Line
-		nextLine := fset.Position(next.Pos()).Line
-
-		if nextLine >= endLine+2 {
-			continue
-		}
-
-		violations = append(violations, rules.Violation{
-			Rule:    "spacing",
-			File:    filename,
-			Line:    nextLine,
-			Message: "missing blank line around type definition",
-		})
-
-		offset := lineStartOffset(lineStarts, nextLine)
-		insertions[offset] = struct{}{}
-	}
-
-	violations = append(violations, typeOrderViolations(file, fset, filename)...)
-	violations = append(violations, embedAdjacencyViolations(file, fset, filename)...)
-
-	formatted := src
-
-	if len(insertions) > 0 {
-		formatted = applyInsertions(formatted, insertions)
-	}
+	formatted := inserter.apply()
 
 	if len(violations) > 0 {
-		reordered, changed, err := reorderTypeDecls(filename, formatted)
+		reordered, changed, err := typeOrder.rewrite(path, formatted)
 
 		if err != nil {
 			return nil, nil, err
@@ -131,7 +53,7 @@ func analyse(filename string, src []byte) ([]rules.Violation, []byte, error) {
 			formatted = reordered
 		}
 
-		formatted, err = repairDetachedEmbedDirectives(filename, formatted)
+		formatted, err = embeds.repair(path, formatted)
 
 		if err != nil {
 			return nil, nil, err

--- a/packages/go/formatter/rules/spacing/typeorder.go
+++ b/packages/go/formatter/rules/spacing/typeorder.go
@@ -21,11 +21,24 @@ type declRegion struct {
 	end   int
 }
 
-func typeOrderViolations(file *ast.File, fset *token.FileSet, filename string) []rules.Violation {
+// typeOrderRewriter enforces that type declarations precede the other top-level
+// declarations in a file, reading the shared parse state through ctx.
+type typeOrderRewriter struct {
+	ctx *fileContext
+}
+
+// newTypeOrderRewriter returns a rewriter bound to the shared parse state.
+func newTypeOrderRewriter(ctx *fileContext) *typeOrderRewriter {
+	return &typeOrderRewriter{ctx: ctx}
+}
+
+// analyze reports every type declaration that appears after a non-type
+// declaration, labelling the returned violations with filename.
+func (r *typeOrderRewriter) analyze(filename string) []rules.Violation {
 	var violations []rules.Violation
 	seenNonType := false
 
-	for _, block := range topLevelDeclBlocks(file) {
+	for _, block := range topLevelDeclBlocks(r.ctx.file) {
 		if isImportDecl(block.decl) {
 			continue
 		}
@@ -41,7 +54,7 @@ func typeOrderViolations(file *ast.File, fset *token.FileSet, filename string) [
 				violations = append(violations, rules.Violation{
 					Rule:    "spacing",
 					File:    filename,
-					Line:    fset.Position(block.decl.Pos()).Line,
+					Line:    r.ctx.fset.Position(block.decl.Pos()).Line,
 					Message: "type definitions must appear at the beginning of the file",
 				})
 			}
@@ -55,7 +68,11 @@ func typeOrderViolations(file *ast.File, fset *token.FileSet, filename string) [
 	return violations
 }
 
-func reorderTypeDecls(filename string, src []byte) ([]byte, bool, error) {
+// rewrite re-parses src — which may already carry the blank lines the inserter
+// added — and splices every type declaration to the front of the file. It parses
+// its own file rather than reusing ctx because it operates on the transformed
+// bytes, and reports whether the declaration order changed.
+func (r *typeOrderRewriter) rewrite(filename string, src []byte) ([]byte, bool, error) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, filename, src, parser.ParseComments)
 


### PR DESCRIPTION
Stage 2/6 (stacks on G1). Behavior-frozen redesign of formatter/rules/spacing: fileContext (parse once: fset/file/src/lineStarts/aliases; kills the package-level stdlibSpacingImports var) shared by three intent types — blankLineInserter, typeOrderRewriter, embedDirectiveRepairer. Rule.Apply becomes a short sequence in the exact original order. Diff touches only the 5 source files: zero test or golden edits. Coverage 95.1%; the repo self-formats through this very rule and stays clean (its own new context.go got dogfood-formatted).