### PR TITLE
refactor(go): G3 — split sourcefiles into gitfiles, filetypes, prettierignore

### DIFF
--- a/packages/go/driver/internal/cli/runner.go
+++ b/packages/go/driver/internal/cli/runner.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	driverconfig "go.ollin.sh/fmtkit/driver/config"
+	"go.ollin.sh/fmtkit/driver/internal/gitfiles"
 	"go.ollin.sh/fmtkit/driver/internal/sourcefiles"
 	driverreport "go.ollin.sh/fmtkit/driver/report"
 	"go.ollin.sh/fmtkit/formatter"
@@ -131,14 +132,9 @@ func (r Runner) runFormatter(ctx context.Context, mode Mode, paths []string, cfg
 }
 
 // changedGoFiles narrows the files the formatter owns down to the ones the
-// working tree has touched.
-//
-// It intersects rather than asking git for `*.go` directly: the engine's walk is
-// what applies cfg's exclusions (vendor, not_path/not_name, generated files),
-// and git knows nothing about those. Taking the engine's list and keeping only
-// what git reports as changed preserves both. Outside a git work tree there is
-// no such thing as "changed", so the error surfaces rather than silently
-// formatting everything.
+// working tree has touched. The engine reports what it owns; gitfiles keeps only
+// the subset git reports as changed (see Tree.IntersectChanged for why this is
+// an intersection rather than a direct `git ls-files *.go`).
 func changedGoFiles(ctx context.Context, paths []string, cfg formatterconfig.Config) ([]string, error) {
 	owned, err := formatterengine.CollectGoFiles(paths, cfg)
 
@@ -156,27 +152,13 @@ func changedGoFiles(ctx context.Context, paths []string, cfg formatterconfig.Con
 		return nil, fmt.Errorf("resolve cwd: %w", err)
 	}
 
-	touched, err := sourcefiles.ChangedPaths(ctx, cwd, paths)
+	tree, err := gitfiles.NewTree(cwd)
 
 	if err != nil {
 		return nil, err
 	}
 
-	changed := make(map[string]struct{}, len(touched))
-
-	for _, path := range touched {
-		changed[path] = struct{}{}
-	}
-
-	files := make([]string, 0, len(owned))
-
-	for _, path := range owned {
-		if _, ok := changed[path]; ok {
-			files = append(files, path)
-		}
-	}
-
-	return files, nil
+	return tree.IntersectChanged(ctx, paths, owned)
 }
 
 func exitCode(mode Mode, result driverreport.Combined) int {

--- a/packages/go/driver/internal/filetypes/filetypes.go
+++ b/packages/go/driver/internal/filetypes/filetypes.go
@@ -1,0 +1,47 @@
+// Package filetypes is the extension taxonomy that decides which files the
+// formatter and linter own. It is pure path classification — no git, no
+// filesystem — so callers can filter a discovered file list without any I/O.
+package filetypes
+
+import "strings"
+
+// Filter classifies paths by extension. IncludeDeclarations, when set, keeps
+// .d.ts declaration files that would otherwise be dropped.
+type Filter struct {
+	IncludeDeclarations bool
+}
+
+// targetSuffixes are the extensions the sidecar knows how to format. The .ts
+// entry also covers .d.ts; whether declarations are kept is decided separately.
+var targetSuffixes = []string{".ts", ".vue", ".html", ".htm", ".md", ".markdown"}
+
+// Formattable reports whether path is one the formatter owns: the TS and Vue
+// families plus the HTML and Markdown documents whose embedded scripts get
+// formatted.
+func (f Filter) Formattable(path string) bool {
+	matched := false
+
+	for _, suffix := range targetSuffixes {
+		if strings.HasSuffix(path, suffix) {
+			matched = true
+
+			break
+		}
+	}
+
+	if !matched {
+		return false
+	}
+
+	return f.IncludeDeclarations || !strings.HasSuffix(path, ".d.ts")
+}
+
+// Lintable reports whether oxlint can lint path: the TS family (minus
+// declarations unless IncludeDeclarations) and Vue, but not HTML or Markdown.
+func (f Filter) Lintable(path string) bool {
+	if !strings.HasSuffix(path, ".ts") && !strings.HasSuffix(path, ".vue") {
+		return false
+	}
+
+	return f.IncludeDeclarations || !strings.HasSuffix(path, ".d.ts")
+}

--- a/packages/go/driver/internal/filetypes/filetypes_test.go
+++ b/packages/go/driver/internal/filetypes/filetypes_test.go
@@ -1,0 +1,59 @@
+package filetypes
+
+import "testing"
+
+func TestFormattable(t *testing.T) {
+	cases := []struct {
+		name                string
+		path                string
+		includeDeclarations bool
+		want                bool
+	}{
+		{"typescript is formattable", "src/app.ts", false, true},
+		{"vue is formattable", "src/component.vue", false, true},
+		{"html is formattable", "src/index.html", false, true},
+		{"htm is formattable", "src/index.htm", false, true},
+		{"markdown md is formattable", "docs/notes.md", false, true},
+		{"markdown long form is formattable", "docs/readme.markdown", false, true},
+		{"unknown extensions are skipped", "src/app.go", false, false},
+		{"declarations drop by default", "src/types.d.ts", false, false},
+		{"declarations kept when requested", "src/types.d.ts", true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := Filter{IncludeDeclarations: tc.includeDeclarations}
+
+			if got := f.Formattable(tc.path); got != tc.want {
+				t.Fatalf("Formattable(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLintable(t *testing.T) {
+	cases := []struct {
+		name                string
+		path                string
+		includeDeclarations bool
+		want                bool
+	}{
+		{"typescript is lintable", "src/app.ts", false, true},
+		{"vue is lintable", "src/component.vue", false, true},
+		{"html is not lintable", "src/index.html", false, false},
+		{"markdown is not lintable", "docs/notes.md", false, false},
+		{"unknown extensions are skipped", "src/app.go", false, false},
+		{"declarations drop by default", "src/types.d.ts", false, false},
+		{"declarations kept when requested", "src/types.d.ts", true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := Filter{IncludeDeclarations: tc.includeDeclarations}
+
+			if got := f.Lintable(tc.path); got != tc.want {
+				t.Fatalf("Lintable(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/packages/go/driver/internal/gitfiles/gitfiles.go
+++ b/packages/go/driver/internal/gitfiles/gitfiles.go
@@ -1,0 +1,229 @@
+// Package gitfiles discovers the files a working tree covers by driving git.
+// It knows how to map a Selection onto the git invocations that list it, parse
+// their NUL-separated output, and resolve those paths against a tree root. It
+// carries no opinion about which files are worth formatting — that taxonomy
+// lives in filetypes — nor about Prettier's ignore list.
+package gitfiles
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// Selection is how much of the working tree a collection covers.
+type Selection int
+
+// Tree is a working-tree root that git commands run against.
+type Tree struct {
+	Dir string
+}
+
+const (
+	// SelectionAll covers every non-ignored file: tracked plus untracked.
+	// This is what `format-all` runs against.
+	SelectionAll Selection = iota
+
+	// SelectionChanged covers only what has actually diverged from HEAD:
+	// modified-but-tracked (staged or not) plus untracked. This is what `format`
+	// runs against, so an everyday format stays proportional to the diff rather
+	// than the repo.
+	SelectionChanged
+)
+
+// gitCommands returns the git invocations whose combined output lists the
+// files s covers under scope. Every command prints NUL-separated paths
+// relative to the directory git runs in.
+func (s Selection) gitCommands(scope string) [][]string {
+	if s == SelectionChanged {
+		return [][]string{
+			// Untracked files, plus tracked ones whose working-tree copy differs
+			// from the index.
+			{"ls-files", "--others", "--modified", "--exclude-standard", "-z", "--", scope},
+
+			// Staged changes are invisible to ls-files' worktree-vs-index view —
+			// a pre-commit hook would otherwise see nothing to format — so they
+			// come from an index-vs-HEAD diff. --relative keeps paths cwd-relative
+			// like ls-files; --diff-filter=d drops staged deletions, which leave
+			// no file to format.
+			{"diff", "--cached", "--name-only", "--relative", "--diff-filter=d", "-z", "--", scope},
+		}
+	}
+
+	return [][]string{{"ls-files", "--cached", "--others", "--exclude-standard", "-z", "--", scope}}
+}
+
+// NewTree returns a Tree rooted at dir. An empty dir resolves to the current
+// working directory, matching the behaviour of the callers that previously
+// defaulted the root themselves.
+func NewTree(dir string) (Tree, error) {
+	if strings.TrimSpace(dir) == "" {
+		cwd, err := os.Getwd()
+
+		if err != nil {
+			return Tree{}, err
+		}
+
+		dir = cwd
+	}
+
+	return Tree{Dir: dir}, nil
+}
+
+// Files lists the paths git reports for sel under scope, a single path git is
+// passed as its pathspec. Entries come back exactly as git prints them —
+// NUL-separated, relative to the tree — with no filtering or ordering applied.
+func (t Tree) Files(ctx context.Context, scope string, sel Selection) ([]string, error) {
+	entries := []string{}
+
+	for _, args := range sel.gitCommands(scope) {
+		found, err := t.runGit(ctx, args)
+
+		if err != nil {
+			return nil, err
+		}
+
+		entries = append(entries, found...)
+	}
+
+	return entries, nil
+}
+
+// ChangedPaths lists every file that diverges from HEAD — modified, staged, or
+// added — under the given scopes, whatever its extension, as absolute cleaned
+// paths, deduplicated and sorted. Callers do their own filtering — the Go
+// formatter, for one, has its own notion of which files it owns.
+//
+// ChangedPaths deliberately skips .prettierignore filtering: it feeds the Go
+// formatter, whose file set has nothing to do with Prettier's JS/TS ignore
+// list.
+func (t Tree) ChangedPaths(ctx context.Context, scopes []string) ([]string, error) {
+	return t.collect(ctx, scopes, SelectionChanged)
+}
+
+// IntersectChanged narrows owned — the file list an engine reports it owns —
+// down to the ones the working tree has touched under scopes.
+//
+// It intersects rather than asking git for the owned extensions directly: the
+// engine's walk is what applies its own exclusions (vendor, not_path/not_name,
+// generated files), and git knows nothing about those. Taking the engine's list
+// and keeping only what git reports as changed preserves both. Outside a git
+// work tree there is no such thing as "changed", so the error surfaces rather
+// than silently formatting everything.
+func (t Tree) IntersectChanged(ctx context.Context, scopes, owned []string) ([]string, error) {
+	touched, err := t.ChangedPaths(ctx, scopes)
+
+	if err != nil {
+		return nil, err
+	}
+
+	changed := make(map[string]struct{}, len(touched))
+
+	for _, path := range touched {
+		changed[path] = struct{}{}
+	}
+
+	files := make([]string, 0, len(owned))
+
+	for _, path := range owned {
+		if _, ok := changed[path]; ok {
+			files = append(files, path)
+		}
+	}
+
+	return files, nil
+}
+
+// collect walks scopes, listing the files sel covers under each, and returns
+// them as absolute cleaned paths, deduplicated and sorted. Missing scopes are
+// skipped silently; any other stat failure surfaces.
+func (t Tree) collect(ctx context.Context, scopes []string, sel Selection) ([]string, error) {
+	if len(scopes) == 0 {
+		scopes = []string{"."}
+	}
+
+	files := []string{}
+	seen := map[string]struct{}{}
+
+	for _, scope := range scopes {
+		absolute := scope
+
+		if !filepath.IsAbs(absolute) {
+			absolute = filepath.Join(t.Dir, scope)
+		}
+
+		if _, err := os.Stat(absolute); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+
+			return nil, err
+		}
+
+		entries, err := t.Files(ctx, absolute, sel)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, entry := range entries {
+			path := entry
+
+			if !filepath.IsAbs(path) {
+				path = filepath.Join(t.Dir, path)
+			}
+
+			path = filepath.Clean(path)
+
+			if _, ok := seen[path]; ok {
+				continue
+			}
+
+			files = append(files, path)
+			seen[path] = struct{}{}
+		}
+	}
+
+	slices.Sort(files)
+
+	return files, nil
+}
+
+func (t Tree) runGit(ctx context.Context, args []string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = t.Dir
+
+	var stderr bytes.Buffer
+
+	cmd.Stderr = &stderr
+
+	out, err := cmd.Output()
+
+	if err != nil {
+		reason := strings.TrimSpace(stderr.String())
+
+		if reason == "" {
+			return nil, fmt.Errorf("git %s failed: %w", args[0], err)
+		}
+
+		return nil, fmt.Errorf("git %s failed: %s: %w", args[0], reason, err)
+	}
+
+	parts := bytes.Split(out, []byte{0})
+	entries := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+
+		entries = append(entries, string(part))
+	}
+
+	return entries, nil
+}

--- a/packages/go/driver/internal/gitfiles/gitfiles_test.go
+++ b/packages/go/driver/internal/gitfiles/gitfiles_test.go
@@ -1,0 +1,267 @@
+package gitfiles
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestNewTreeDefaultsToWorkingDirectory(t *testing.T) {
+	tree, err := NewTree("")
+
+	if err != nil {
+		t.Fatalf("new tree: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	if tree.Dir != cwd {
+		t.Fatalf("empty dir must resolve to cwd\nwant: %q\n got: %q", cwd, tree.Dir)
+	}
+}
+
+func TestNewTreeKeepsGivenDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	tree, err := NewTree(dir)
+
+	if err != nil {
+		t.Fatalf("new tree: %v", err)
+	}
+
+	if tree.Dir != dir {
+		t.Fatalf("dir mismatch\nwant: %q\n got: %q", dir, tree.Dir)
+	}
+}
+
+func TestFilesListsTrackedAndUntracked(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, "tracked.ts"), "const value = 1;\n")
+	gitAdd(t, dir, "tracked.ts")
+	writeFile(t, filepath.Join(dir, "untracked.ts"), "const other = 2;\n")
+
+	tree, err := NewTree(dir)
+
+	if err != nil {
+		t.Fatalf("new tree: %v", err)
+	}
+
+	entries, err := tree.Files(context.Background(), dir, SelectionAll)
+
+	if err != nil {
+		t.Fatalf("files: %v", err)
+	}
+
+	// git prints paths relative to the tree; order is git's own, so compare sets.
+	got := map[string]struct{}{}
+
+	for _, entry := range entries {
+		got[entry] = struct{}{}
+	}
+
+	want := map[string]struct{}{"tracked.ts": {}, "untracked.ts": {}}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("entries mismatch\nwant: %#v\n got: %#v", want, got)
+	}
+}
+
+func TestFilesSurfacesGitErrorsOutsideARepo(t *testing.T) {
+	dir := t.TempDir()
+
+	tree, err := NewTree(dir)
+
+	if err != nil {
+		t.Fatalf("new tree: %v", err)
+	}
+
+	if _, err := tree.Files(context.Background(), dir, SelectionAll); err == nil {
+		t.Fatal("expected an error running git outside a work tree")
+	}
+}
+
+func TestChangedPathsCoversOnlyTheWorkingTreesChanges(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, "untouched.ts"), "const untouched = 1;\n")
+	writeFile(t, filepath.Join(dir, "modified.ts"), "const modified = 1;\n")
+	gitAdd(t, dir, "untouched.ts", "modified.ts")
+	gitCommit(t, dir)
+
+	writeFile(t, filepath.Join(dir, "modified.ts"), "const modified = 2;\n")
+	writeFile(t, filepath.Join(dir, "added.ts"), "const added = 3;\n")
+
+	tree, err := NewTree(dir)
+
+	if err != nil {
+		t.Fatalf("new tree: %v", err)
+	}
+
+	files, err := tree.ChangedPaths(context.Background(), nil)
+
+	if err != nil {
+		t.Fatalf("changed paths: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(dir, "added.ts"),
+		filepath.Join(dir, "modified.ts"),
+	}
+
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("files mismatch\nwant: %#v\n got: %#v", want, files)
+	}
+}
+
+func TestChangedPathsIgnoresPrettierIgnore(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, ".prettierignore"), "main.go\n")
+	writeFile(t, filepath.Join(dir, "main.go"), "package main\n")
+	gitAdd(t, dir, ".")
+
+	tree, err := NewTree(dir)
+
+	if err != nil {
+		t.Fatalf("new tree: %v", err)
+	}
+
+	files, err := tree.ChangedPaths(context.Background(), nil)
+
+	if err != nil {
+		t.Fatalf("changed paths: %v", err)
+	}
+
+	// The Go lane must still see main.go even though .prettierignore lists it:
+	// gitfiles never consults .prettierignore.
+	want := []string{
+		filepath.Join(dir, ".prettierignore"),
+		filepath.Join(dir, "main.go"),
+	}
+
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("files mismatch\nwant: %#v\n got: %#v", want, files)
+	}
+}
+
+func TestChangedPathsSkipsMissingScopes(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, "src", "app.ts"), "const value = 1;\n")
+	gitAdd(t, dir, ".")
+
+	tree, err := NewTree(dir)
+
+	if err != nil {
+		t.Fatalf("new tree: %v", err)
+	}
+
+	files, err := tree.ChangedPaths(context.Background(), []string{"src", "missing"})
+
+	if err != nil {
+		t.Fatalf("changed paths: %v", err)
+	}
+
+	want := []string{filepath.Join(dir, "src", "app.ts")}
+
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("files mismatch\nwant: %#v\n got: %#v", want, files)
+	}
+}
+
+func TestIntersectChangedKeepsOnlyOwnedAndChanged(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, "changed.go"), "package main\n")
+	writeFile(t, filepath.Join(dir, "untracked.go"), "package main\n")
+	gitAdd(t, dir, ".")
+
+	tree, err := NewTree(dir)
+
+	if err != nil {
+		t.Fatalf("new tree: %v", err)
+	}
+
+	owned := []string{
+		filepath.Join(dir, "changed.go"),
+		// Owned by the engine but not reported as changed by git.
+		filepath.Join(dir, "vendored.go"),
+	}
+
+	files, err := tree.IntersectChanged(context.Background(), nil, owned)
+
+	if err != nil {
+		t.Fatalf("intersect changed: %v", err)
+	}
+
+	// Order follows owned, and only the git-changed intersection survives.
+	want := []string{filepath.Join(dir, "changed.go")}
+
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("files mismatch\nwant: %#v\n got: %#v", want, files)
+	}
+}
+
+func TestIntersectChangedSurfacesGitErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	tree, err := NewTree(dir)
+
+	if err != nil {
+		t.Fatalf("new tree: %v", err)
+	}
+
+	if _, err := tree.IntersectChanged(context.Background(), nil, []string{filepath.Join(dir, "a.go")}); err == nil {
+		t.Fatal("expected an error running git outside a work tree")
+	}
+}
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	run(t, dir, "git", "init", "-q")
+	run(t, dir, "git", "config", "user.email", "tests@example.com")
+	run(t, dir, "git", "config", "user.name", "Test Runner")
+
+	return dir
+}
+
+func gitAdd(t *testing.T, dir string, paths ...string) {
+	t.Helper()
+
+	args := append([]string{"add"}, paths...)
+	run(t, dir, "git", args...)
+}
+
+func gitCommit(t *testing.T, dir string) {
+	t.Helper()
+
+	run(t, dir, "git", "commit", "-q", "-m", "fixture")
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func run(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s %v: %v\n%s", name, args, err, out)
+	}
+}

--- a/packages/go/driver/internal/prettierignore/prettierignore.go
+++ b/packages/go/driver/internal/prettierignore/prettierignore.go
@@ -1,18 +1,22 @@
-package sourcefiles
+// Package prettierignore matches repo-relative paths against a project's
+// .prettierignore file using gitignore semantics, and filters absolute file
+// lists by it.
+package prettierignore
 
 import (
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
 
-// prettierIgnore matches repo-relative paths against a parsed .prettierignore
-// file using gitignore semantics. Supported constructs: comments (#), blank
-// lines, negation (!, last match wins), leading-/ anchoring, trailing-/
-// directory patterns, and the * ? [...] and ** wildcards. Exotic constructs —
-// escaped leading #/! (\# and \!) and trailing-space escapes — are not
-// supported: a leading # or ! is always read as a comment or a negation.
-type prettierIgnore struct {
+// Matcher matches repo-relative paths against a parsed .prettierignore file
+// using gitignore semantics. Supported constructs: comments (#), blank lines,
+// negation (!, last match wins), leading-/ anchoring, trailing-/ directory
+// patterns, and the * ? [...] and ** wildcards. Exotic constructs — escaped
+// leading #/! (\# and \!) and trailing-space escapes — are not supported: a
+// leading # or ! is always read as a comment or a negation.
+type Matcher struct {
 	patterns []ignorePattern
 }
 
@@ -23,10 +27,10 @@ type ignorePattern struct {
 	dirOnly bool
 }
 
-// loadPrettierIgnore reads the .prettierignore at path and compiles it. It
-// returns nil (and no error) when the file is absent, so callers can treat "no
-// file" as "nothing filtered".
-func loadPrettierIgnore(path string) (*prettierIgnore, error) {
+// Load reads the .prettierignore at path and compiles it. It returns nil (and
+// no error) when the file is absent, so callers can treat "no file" as "nothing
+// filtered".
+func Load(path string) (*Matcher, error) {
 	data, err := os.ReadFile(path)
 
 	if err != nil {
@@ -37,21 +41,47 @@ func loadPrettierIgnore(path string) (*prettierIgnore, error) {
 		return nil, err
 	}
 
-	return compilePrettierIgnore(data), nil
+	return Compile(data), nil
 }
 
-// compilePrettierIgnore parses raw .prettierignore bytes into matchable
-// patterns, skipping blank lines, comments, and lines that fail to compile.
-func compilePrettierIgnore(data []byte) *prettierIgnore {
-	ignore := &prettierIgnore{}
+// Compile parses raw .prettierignore bytes into matchable patterns, skipping
+// blank lines, comments, and lines that fail to compile.
+func Compile(data []byte) *Matcher {
+	matcher := &Matcher{}
 
 	for _, line := range strings.Split(string(data), "\n") {
 		if pattern, ok := compilePattern(line); ok {
-			ignore.patterns = append(ignore.patterns, pattern)
+			matcher.patterns = append(matcher.patterns, pattern)
 		}
 	}
 
-	return ignore
+	return matcher
+}
+
+// FilterAbs drops any path in files that the matcher excludes, treating each
+// path as relative to root. Paths outside root are kept untouched:
+// .prettierignore is anchored to the directory that holds it and cannot speak
+// to files above it.
+func (m *Matcher) FilterAbs(root string, files []string) ([]string, error) {
+	kept := make([]string, 0, len(files))
+
+	for _, path := range files {
+		rel, err := filepath.Rel(root, path)
+
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			kept = append(kept, path)
+
+			continue
+		}
+
+		if m.Ignores(filepath.ToSlash(rel)) {
+			continue
+		}
+
+		kept = append(kept, path)
+	}
+
+	return kept, nil
 }
 
 // compilePattern turns one raw line into an ignorePattern, reporting false for
@@ -108,13 +138,13 @@ func compilePattern(line string) (ignorePattern, bool) {
 	}, true
 }
 
-// ignores reports whether rel — a slash-separated path relative to the ignore
+// Ignores reports whether rel — a slash-separated path relative to the ignore
 // file's directory — is excluded. Later matches win, so a negation can
 // re-include a path an earlier pattern excluded.
-func (p *prettierIgnore) ignores(rel string) bool {
+func (m *Matcher) Ignores(rel string) bool {
 	ignored := false
 
-	for _, pattern := range p.patterns {
+	for _, pattern := range m.patterns {
 		if pattern.matches(rel) {
 			ignored = !pattern.negated
 		}

--- a/packages/go/driver/internal/prettierignore/prettierignore_test.go
+++ b/packages/go/driver/internal/prettierignore/prettierignore_test.go
@@ -1,0 +1,128 @@
+package prettierignore
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestMatcherIgnores(t *testing.T) {
+	cases := []struct {
+		name     string
+		ignore   string
+		path     string
+		excluded bool
+	}{
+		{"blank and comment lines are inert", "\n# comment\n", "app.ts", false},
+		{"plain name matches at root", "app.ts\n", "app.ts", true},
+		{"plain name matches at any depth", "app.ts\n", "src/nested/app.ts", true},
+		{"plain name does not match a different file", "app.ts\n", "app.tsx", false},
+		{"leading slash anchors to root", "/app.ts\n", "app.ts", true},
+		{"leading slash rejects nested", "/app.ts\n", "src/app.ts", false},
+		{"trailing slash matches under a directory", "dist/\n", "dist/app.ts", true},
+		{"trailing slash does not match a file of that name", "dist/\n", "dist", false},
+		{"star stays within a segment", "*.ts\n", "src/app.ts", true},
+		{"star does not cross a slash", "src/*.ts\n", "src/nested/app.ts", false},
+		{"question matches one char", "app.?s\n", "app.ts", true},
+		{"question needs exactly one char", "app.?s\n", "app.tss", false},
+		{"character class matches a member", "app.[jt]s\n", "app.ts", true},
+		{"character class rejects a non-member", "app.[jt]s\n", "app.xs", false},
+		{"negated class rejects a member", "app.[!t]s\n", "app.ts", false},
+		{"negated class matches a non-member", "app.[!t]s\n", "app.js", true},
+		{"double star spans segments", "src/**/app.ts\n", "src/a/b/app.ts", true},
+		{"double star spans zero segments", "src/**/app.ts\n", "src/app.ts", true},
+		{"trailing double star matches everything below", "logs/**\n", "logs/a/b.txt", true},
+		{"leading double star matches at any depth", "**/gen.ts\n", "a/b/gen.ts", true},
+		{"excluding a directory excludes its contents", "build\n", "build/x/y.ts", true},
+		{"a similarly named directory is untouched", "build\n", "prebuild/x.ts", false},
+		{"negation re-includes a previously excluded file", "*.ts\n!keep.ts\n", "keep.ts", false},
+		{"order matters: re-exclude after negation", "*.ts\n!keep.ts\nkeep.ts\n", "keep.ts", true},
+		{"unclosed bracket is a literal", "a[b.ts\n", "a[b.ts", true},
+		{"invalid character class is skipped without panicking", "[z-a]\napp.ts\n", "app.ts", true},
+		{"invalid character class does not match its own line", "[z-a]\n", "z", false},
+		{"crlf line trims the carriage return before spaces", "foo \r\n", "foo", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matcher := Compile([]byte(tc.ignore))
+
+			if got := matcher.Ignores(tc.path); got != tc.excluded {
+				t.Fatalf("Ignores(%q) = %v, want %v", tc.path, got, tc.excluded)
+			}
+		})
+	}
+}
+
+func TestLoadAbsentFile(t *testing.T) {
+	matcher, err := Load(filepath.Join(t.TempDir(), ".prettierignore"))
+
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if matcher != nil {
+		t.Fatalf("expected nil matcher for absent file, got %#v", matcher)
+	}
+}
+
+func TestLoadCompilesPresentFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".prettierignore")
+
+	if err := os.WriteFile(path, []byte("dist/\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	matcher, err := Load(path)
+
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if matcher == nil || !matcher.Ignores("dist/bundle.ts") {
+		t.Fatalf("expected the loaded matcher to honour dist/, got %#v", matcher)
+	}
+}
+
+func TestLoadSurfacesReadErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	// A directory named .prettierignore is not IsNotExist, so its read error must
+	// surface rather than being swallowed as "no file".
+	if err := os.Mkdir(filepath.Join(dir, ".prettierignore"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if _, err := Load(filepath.Join(dir, ".prettierignore")); err == nil {
+		t.Fatal("expected an error reading a directory as .prettierignore")
+	}
+}
+
+func TestFilterAbsDropsIgnoredAndKeepsOutsiders(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "project", "root")
+	matcher := Compile([]byte("dist/\n"))
+
+	files := []string{
+		filepath.Join(root, "src", "app.ts"),
+		filepath.Join(root, "dist", "bundle.ts"),
+		// Above root: .prettierignore cannot speak to it, so it is kept untouched.
+		filepath.Join(string(filepath.Separator), "project", "sibling.ts"),
+	}
+
+	kept, err := matcher.FilterAbs(root, files)
+
+	if err != nil {
+		t.Fatalf("FilterAbs: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(root, "src", "app.ts"),
+		filepath.Join(string(filepath.Separator), "project", "sibling.ts"),
+	}
+
+	if !reflect.DeepEqual(kept, want) {
+		t.Fatalf("kept mismatch\nwant: %#v\n got: %#v", want, kept)
+	}
+}

--- a/packages/go/driver/internal/sourcefiles/command.go
+++ b/packages/go/driver/internal/sourcefiles/command.go
@@ -8,7 +8,17 @@ import (
 	"os"
 )
 
+// Run is the transitional entry point kept so existing callers compile
+// unchanged; it delegates to RunCLI.
+//
+// Transitional: G5 adopts RunCLI directly.
 func Run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	return RunCLI(ctx, args, stdout, stderr)
+}
+
+// RunCLI parses the `sources` subcommand flags and prints the collected files
+// NUL-separated to stdout.
+func RunCLI(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("sources", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 

--- a/packages/go/driver/internal/sourcefiles/command_test.go
+++ b/packages/go/driver/internal/sourcefiles/command_test.go
@@ -1,0 +1,145 @@
+package sourcefiles
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunCLIPrintsNULSeparatedFiles(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, "src", "app.ts"), "const value = 1;\n")
+	writeFile(t, filepath.Join(dir, "src", "notes.md"), "# Notes\n")
+	writeFile(t, filepath.Join(dir, "src", "types.d.ts"), "declare const value: string;\n")
+	gitAdd(t, dir, ".")
+
+	var stdout, stderr bytes.Buffer
+
+	code := RunCLI(context.Background(), []string{"--cwd", dir, "src"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("RunCLI exit = %d, stderr: %s", code, stderr.String())
+	}
+
+	got := splitNUL(stdout.String())
+
+	want := []string{
+		filepath.Join(dir, "src", "app.ts"),
+		filepath.Join(dir, "src", "notes.md"),
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("files mismatch\nwant: %#v\n got: %#v", want, got)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("files mismatch\nwant: %#v\n got: %#v", want, got)
+		}
+	}
+}
+
+func TestRunCLIIncludesDeclarationsFlag(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, "types.d.ts"), "declare const value: string;\n")
+	gitAdd(t, dir, ".")
+
+	var stdout, stderr bytes.Buffer
+
+	code := RunCLI(context.Background(), []string{"--cwd", dir, "--include-declarations"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("RunCLI exit = %d, stderr: %s", code, stderr.String())
+	}
+
+	got := splitNUL(stdout.String())
+
+	if len(got) != 1 || got[0] != filepath.Join(dir, "types.d.ts") {
+		t.Fatalf("expected the declaration file, got %#v", got)
+	}
+}
+
+func TestRunCLIWarnsOnMissingScopes(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, "app.ts"), "const value = 1;\n")
+	gitAdd(t, dir, ".")
+
+	var stdout, stderr bytes.Buffer
+
+	code := RunCLI(context.Background(), []string{"--cwd", dir, "missing"}, &stdout, &stderr)
+
+	if code != 0 {
+		t.Fatalf("RunCLI exit = %d", code)
+	}
+
+	if !strings.Contains(stderr.String(), "[sources] path not found, skipping") {
+		t.Fatalf("expected a missing-path warning, got stderr: %q", stderr.String())
+	}
+}
+
+func TestRunCLIDefaultsToWorkingDirectory(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, "app.ts"), "const value = 1;\n")
+	gitAdd(t, dir, ".")
+	t.Chdir(dir)
+
+	var stdout, stderr bytes.Buffer
+
+	if code := RunCLI(context.Background(), nil, &stdout, &stderr); code != 0 {
+		t.Fatalf("RunCLI exit = %d, stderr: %s", code, stderr.String())
+	}
+
+	got := splitNUL(stdout.String())
+
+	// With no --cwd, RunCLI resolves the process working directory itself.
+	if len(got) != 1 || got[0] != filepath.Join(dir, "app.ts") {
+		t.Fatalf("expected app.ts under the resolved cwd, got %#v", got)
+	}
+}
+
+func TestRunCLIReportsBadFlags(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	if code := RunCLI(context.Background(), []string{"--nope"}, &stdout, &stderr); code != 1 {
+		t.Fatalf("expected exit 1 for an unknown flag, got %d", code)
+	}
+}
+
+func TestRunDelegatesToRunCLI(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, "app.ts"), "const value = 1;\n")
+	gitAdd(t, dir, ".")
+
+	var stdout, stderr bytes.Buffer
+
+	if code := Run(context.Background(), []string{"--cwd", dir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("Run exit = %d, stderr: %s", code, stderr.String())
+	}
+
+	got := splitNUL(stdout.String())
+
+	if len(got) != 1 || got[0] != filepath.Join(dir, "app.ts") {
+		t.Fatalf("Run output mismatch, got %#v", got)
+	}
+}
+
+func splitNUL(s string) []string {
+	if s == "" {
+		return nil
+	}
+
+	parts := strings.Split(s, "\x00")
+	out := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+
+		out = append(out, part)
+	}
+
+	return out
+}

--- a/packages/go/driver/internal/sourcefiles/prettierignore_test.go
+++ b/packages/go/driver/internal/sourcefiles/prettierignore_test.go
@@ -8,66 +8,6 @@ import (
 	"testing"
 )
 
-func TestPrettierIgnoreMatches(t *testing.T) {
-	cases := []struct {
-		name     string
-		ignore   string
-		path     string
-		excluded bool
-	}{
-		{"blank and comment lines are inert", "\n# comment\n", "app.ts", false},
-		{"plain name matches at root", "app.ts\n", "app.ts", true},
-		{"plain name matches at any depth", "app.ts\n", "src/nested/app.ts", true},
-		{"plain name does not match a different file", "app.ts\n", "app.tsx", false},
-		{"leading slash anchors to root", "/app.ts\n", "app.ts", true},
-		{"leading slash rejects nested", "/app.ts\n", "src/app.ts", false},
-		{"trailing slash matches under a directory", "dist/\n", "dist/app.ts", true},
-		{"trailing slash does not match a file of that name", "dist/\n", "dist", false},
-		{"star stays within a segment", "*.ts\n", "src/app.ts", true},
-		{"star does not cross a slash", "src/*.ts\n", "src/nested/app.ts", false},
-		{"question matches one char", "app.?s\n", "app.ts", true},
-		{"question needs exactly one char", "app.?s\n", "app.tss", false},
-		{"character class matches a member", "app.[jt]s\n", "app.ts", true},
-		{"character class rejects a non-member", "app.[jt]s\n", "app.xs", false},
-		{"negated class rejects a member", "app.[!t]s\n", "app.ts", false},
-		{"negated class matches a non-member", "app.[!t]s\n", "app.js", true},
-		{"double star spans segments", "src/**/app.ts\n", "src/a/b/app.ts", true},
-		{"double star spans zero segments", "src/**/app.ts\n", "src/app.ts", true},
-		{"trailing double star matches everything below", "logs/**\n", "logs/a/b.txt", true},
-		{"leading double star matches at any depth", "**/gen.ts\n", "a/b/gen.ts", true},
-		{"excluding a directory excludes its contents", "build\n", "build/x/y.ts", true},
-		{"a similarly named directory is untouched", "build\n", "prebuild/x.ts", false},
-		{"negation re-includes a previously excluded file", "*.ts\n!keep.ts\n", "keep.ts", false},
-		{"order matters: re-exclude after negation", "*.ts\n!keep.ts\nkeep.ts\n", "keep.ts", true},
-		{"unclosed bracket is a literal", "a[b.ts\n", "a[b.ts", true},
-		{"invalid character class is skipped without panicking", "[z-a]\napp.ts\n", "app.ts", true},
-		{"invalid character class does not match its own line", "[z-a]\n", "z", false},
-		{"crlf line trims the carriage return before spaces", "foo \r\n", "foo", true},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			ignore := compilePrettierIgnore([]byte(tc.ignore))
-
-			if got := ignore.ignores(tc.path); got != tc.excluded {
-				t.Fatalf("ignores(%q) = %v, want %v", tc.path, got, tc.excluded)
-			}
-		})
-	}
-}
-
-func TestLoadPrettierIgnoreAbsentFile(t *testing.T) {
-	ignore, err := loadPrettierIgnore(filepath.Join(t.TempDir(), ".prettierignore"))
-
-	if err != nil {
-		t.Fatalf("loadPrettierIgnore: %v", err)
-	}
-
-	if ignore != nil {
-		t.Fatalf("expected nil matcher for absent file, got %#v", ignore)
-	}
-}
-
 func TestCollectSurfacesUnreadablePrettierIgnore(t *testing.T) {
 	dir := initRepo(t)
 	writeFile(t, filepath.Join(dir, "app.ts"), "const value = 1;\n")
@@ -123,29 +63,6 @@ func TestCollectLintableHonorsPrettierIgnore(t *testing.T) {
 	}
 
 	want := []string{filepath.Join(dir, "app.ts")}
-
-	if !reflect.DeepEqual(files, want) {
-		t.Fatalf("files mismatch\nwant: %#v\n got: %#v", want, files)
-	}
-}
-
-func TestChangedPathsIgnoresPrettierIgnore(t *testing.T) {
-	dir := initRepo(t)
-	writeFile(t, filepath.Join(dir, ".prettierignore"), "main.go\n")
-	writeFile(t, filepath.Join(dir, "main.go"), "package main\n")
-	gitAdd(t, dir, ".")
-
-	files, err := ChangedPaths(context.Background(), dir, nil)
-
-	if err != nil {
-		t.Fatalf("changed paths: %v", err)
-	}
-
-	// The Go lane must still see main.go even though .prettierignore lists it.
-	want := []string{
-		filepath.Join(dir, ".prettierignore"),
-		filepath.Join(dir, "main.go"),
-	}
 
 	if !reflect.DeepEqual(files, want) {
 		t.Fatalf("files mismatch\nwant: %#v\n got: %#v", want, files)

--- a/packages/go/driver/internal/sourcefiles/sourcefiles.go
+++ b/packages/go/driver/internal/sourcefiles/sourcefiles.go
@@ -1,19 +1,37 @@
+// Package sourcefiles composes the three source-discovery engines — git file
+// discovery (gitfiles), the extension taxonomy (filetypes), and the
+// .prettierignore matcher (prettierignore) — into the file lists the TS
+// toolchain formats and lints.
 package sourcefiles
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
-	"strings"
+
+	"go.ollin.sh/fmtkit/driver/internal/filetypes"
+	"go.ollin.sh/fmtkit/driver/internal/gitfiles"
+	"go.ollin.sh/fmtkit/driver/internal/prettierignore"
 )
 
-// Selection is how much of the working tree a collection covers.
-type Selection int
+// Selection re-exports gitfiles.Selection so existing callers keep compiling.
+//
+// Transitional: G5 adopts gitfiles.Selection directly.
+type Selection = gitfiles.Selection
 
+// Collector composes git discovery, the extension taxonomy, and the
+// .prettierignore matcher into the formatter's and linter's file lists.
+type Collector struct {
+	Tree      gitfiles.Tree
+	Selection gitfiles.Selection
+	Filter    filetypes.Filter
+}
+
+// Options configures the transitional Collect/CollectLintable wrappers.
+//
+// Transitional: G5 adopts Collector directly.
 type Options struct {
 	Cwd                 string
 	IncludeDeclarations bool
@@ -25,81 +43,32 @@ type Options struct {
 
 const (
 	// SelectionAll covers every non-ignored file: tracked plus untracked.
-	// This is what `format-all` runs against.
-	SelectionAll Selection = iota
+	//
+	// Transitional: G5 adopts gitfiles.SelectionAll directly.
+	SelectionAll = gitfiles.SelectionAll
 
-	// SelectionChanged covers only what has actually diverged from HEAD:
-	// modified-but-tracked (staged or not) plus untracked. This is what `format`
-	// runs against, so an everyday format stays proportional to the diff rather
-	// than the repo.
-	SelectionChanged
+	// SelectionChanged covers only what has diverged from HEAD.
+	//
+	// Transitional: G5 adopts gitfiles.SelectionChanged directly.
+	SelectionChanged = gitfiles.SelectionChanged
 )
 
-// gitCommands returns the git invocations whose combined output lists the
-// files s covers under scope. Every command prints NUL-separated paths
-// relative to the directory git runs in.
-func (s Selection) gitCommands(scope string) [][]string {
-	if s == SelectionChanged {
-		return [][]string{
-			// Untracked files, plus tracked ones whose working-tree copy differs
-			// from the index.
-			{"ls-files", "--others", "--modified", "--exclude-standard", "-z", "--", scope},
-
-			// Staged changes are invisible to ls-files' worktree-vs-index view —
-			// a pre-commit hook would otherwise see nothing to format — so they
-			// come from an index-vs-HEAD diff. --relative keeps paths cwd-relative
-			// like ls-files; --diff-filter=d drops staged deletions, which leave
-			// no file to format.
-			{"diff", "--cached", "--name-only", "--relative", "--diff-filter=d", "-z", "--", scope},
-		}
-	}
-
-	return [][]string{{"ls-files", "--cached", "--others", "--exclude-standard", "-z", "--", scope}}
-}
-
-// Collect lists the files the formatter owns under the given scopes: the TS
+// Formattable lists the files the formatter owns under the given scopes: the TS
 // and Vue families plus the HTML and Markdown documents whose embedded scripts
-// get formatted.
-func Collect(ctx context.Context, opts Options) ([]string, []string, error) {
-	return collect(ctx, opts.Cwd, opts.Scopes, opts.Selection, true, func(path string) bool {
-		return isTargetFile(path, opts.IncludeDeclarations)
-	})
+// get formatted. It returns warnings for scopes that do not exist.
+func (c Collector) Formattable(ctx context.Context, scopes []string) ([]string, []string, error) {
+	return c.collect(ctx, scopes, c.Filter.Formattable)
 }
 
-// CollectLintable lists only the files oxlint can lint under the given scopes:
-// the TS and Vue families. It is a subset of Collect — HTML and Markdown are
+// Lintable lists only the files oxlint can lint under the given scopes: the TS
+// and Vue families. It is a subset of Formattable — HTML and Markdown are
 // formattable but not lintable.
-func CollectLintable(ctx context.Context, opts Options) ([]string, []string, error) {
-	return collect(ctx, opts.Cwd, opts.Scopes, opts.Selection, true, func(path string) bool {
-		return isLintableFile(path, opts.IncludeDeclarations)
-	})
+func (c Collector) Lintable(ctx context.Context, scopes []string) ([]string, []string, error) {
+	return c.collect(ctx, scopes, c.Filter.Lintable)
 }
 
-// ChangedPaths lists every file that diverges from HEAD — modified, staged, or
-// added — under the given scopes, whatever its extension. Callers do their own
-// filtering — the Go formatter, for one, has its own notion of which files it
-// owns.
-// ChangedPaths deliberately skips .prettierignore filtering: it feeds the Go
-// formatter, whose file set has nothing to do with Prettier's JS/TS ignore
-// list.
-func ChangedPaths(ctx context.Context, cwd string, scopes []string) ([]string, error) {
-	files, _, err := collect(ctx, cwd, scopes, SelectionChanged, false, func(string) bool {
-		return true
-	})
-
-	return files, err
-}
-
-func collect(ctx context.Context, cwd string, scopes []string, selection Selection, honorPrettierIgnore bool, keep func(string) bool) ([]string, []string, error) {
-	if strings.TrimSpace(cwd) == "" {
-		var err error
-
-		cwd, err = os.Getwd()
-
-		if err != nil {
-			return nil, nil, err
-		}
-	}
+func (c Collector) collect(ctx context.Context, scopes []string, keep func(string) bool) ([]string, []string, error) {
+	cwd := c.Tree.Dir
 
 	if len(scopes) == 0 {
 		scopes = []string{"."}
@@ -126,7 +95,7 @@ func collect(ctx context.Context, cwd string, scopes []string, selection Selecti
 			return nil, warnings, err
 		}
 
-		entries, err := gitFiles(ctx, cwd, absolute, selection)
+		entries, err := c.Tree.Files(ctx, absolute, c.Selection)
 
 		if err != nil {
 			return nil, warnings, err
@@ -154,134 +123,85 @@ func collect(ctx context.Context, cwd string, scopes []string, selection Selecti
 		}
 	}
 
-	if honorPrettierIgnore {
-		kept, err := filterPrettierIgnored(cwd, files)
+	kept, err := c.honorPrettierIgnore(cwd, files)
 
-		if err != nil {
-			return nil, warnings, err
-		}
-
-		files = kept
+	if err != nil {
+		return nil, warnings, err
 	}
+
+	files = kept
 
 	slices.Sort(files)
 
 	return files, warnings, nil
 }
 
-// filterPrettierIgnored drops any collected path the project's .prettierignore
-// excludes. Paths outside cwd are kept untouched: .prettierignore is anchored
-// to the directory that holds it and cannot speak to files above it.
-func filterPrettierIgnored(cwd string, files []string) ([]string, error) {
-	ignore, err := loadPrettierIgnore(filepath.Join(cwd, ".prettierignore"))
+// honorPrettierIgnore drops any collected path the project's .prettierignore
+// excludes. When there is no .prettierignore, the files pass through unchanged.
+func (c Collector) honorPrettierIgnore(cwd string, files []string) ([]string, error) {
+	matcher, err := prettierignore.Load(filepath.Join(cwd, ".prettierignore"))
 
 	if err != nil {
 		return nil, err
 	}
 
-	if ignore == nil {
+	if matcher == nil {
 		return files, nil
 	}
 
-	kept := make([]string, 0, len(files))
-
-	for _, path := range files {
-		rel, err := filepath.Rel(cwd, path)
-
-		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			kept = append(kept, path)
-
-			continue
-		}
-
-		if ignore.ignores(filepath.ToSlash(rel)) {
-			continue
-		}
-
-		kept = append(kept, path)
-	}
-
-	return kept, nil
+	return matcher.FilterAbs(cwd, files)
 }
 
-func gitFiles(ctx context.Context, cwd, scope string, selection Selection) ([]string, error) {
-	entries := []string{}
-
-	for _, args := range selection.gitCommands(scope) {
-		found, err := runGit(ctx, cwd, args)
-
-		if err != nil {
-			return nil, err
-		}
-
-		entries = append(entries, found...)
-	}
-
-	return entries, nil
-}
-
-func runGit(ctx context.Context, cwd string, args []string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = cwd
-
-	var stderr bytes.Buffer
-
-	cmd.Stderr = &stderr
-
-	out, err := cmd.Output()
+// Collect lists the files the formatter owns under the given scopes.
+//
+// Transitional: G5 adopts Collector directly.
+func Collect(ctx context.Context, opts Options) ([]string, []string, error) {
+	collector, err := collectorFor(opts)
 
 	if err != nil {
-		reason := strings.TrimSpace(stderr.String())
-
-		if reason == "" {
-			return nil, fmt.Errorf("git %s failed: %w", args[0], err)
-		}
-
-		return nil, fmt.Errorf("git %s failed: %s: %w", args[0], reason, err)
+		return nil, nil, err
 	}
 
-	parts := bytes.Split(out, []byte{0})
-	entries := make([]string, 0, len(parts))
-
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		entries = append(entries, string(part))
-	}
-
-	return entries, nil
+	return collector.Formattable(ctx, opts.Scopes)
 }
 
-// targetSuffixes are the extensions the sidecar knows how to format. The .ts
-// entry also covers .d.ts; whether declarations are kept is decided separately.
-var targetSuffixes = []string{".ts", ".vue", ".html", ".htm", ".md", ".markdown"}
+// CollectLintable lists only the files oxlint can lint under the given scopes.
+//
+// Transitional: G5 adopts Collector directly.
+func CollectLintable(ctx context.Context, opts Options) ([]string, []string, error) {
+	collector, err := collectorFor(opts)
 
-func isTargetFile(path string, includeDeclarations bool) bool {
-	matched := false
-
-	for _, suffix := range targetSuffixes {
-		if strings.HasSuffix(path, suffix) {
-			matched = true
-
-			break
-		}
+	if err != nil {
+		return nil, nil, err
 	}
 
-	if !matched {
-		return false
-	}
-
-	return includeDeclarations || !strings.HasSuffix(path, ".d.ts")
+	return collector.Lintable(ctx, opts.Scopes)
 }
 
-// isLintableFile reports whether oxlint can lint path: the TS family (minus
-// declarations unless includeDeclarations) and Vue, but not HTML or Markdown.
-func isLintableFile(path string, includeDeclarations bool) bool {
-	if !strings.HasSuffix(path, ".ts") && !strings.HasSuffix(path, ".vue") {
-		return false
+// ChangedPaths lists every file that diverges from HEAD under the given scopes,
+// whatever its extension, skipping .prettierignore filtering.
+//
+// Transitional: G5 adopts gitfiles.Tree directly.
+func ChangedPaths(ctx context.Context, cwd string, scopes []string) ([]string, error) {
+	tree, err := gitfiles.NewTree(cwd)
+
+	if err != nil {
+		return nil, err
 	}
 
-	return includeDeclarations || !strings.HasSuffix(path, ".d.ts")
+	return tree.ChangedPaths(ctx, scopes)
+}
+
+func collectorFor(opts Options) (Collector, error) {
+	tree, err := gitfiles.NewTree(opts.Cwd)
+
+	if err != nil {
+		return Collector{}, err
+	}
+
+	return Collector{
+		Tree:      tree,
+		Selection: opts.Selection,
+		Filter:    filetypes.Filter{IncludeDeclarations: opts.IncludeDeclarations},
+	}, nil
 }

--- a/packages/go/driver/internal/sourcefiles/sourcefiles_test.go
+++ b/packages/go/driver/internal/sourcefiles/sourcefiles_test.go
@@ -191,6 +191,29 @@ func TestCollectScopesAndDeduplicatesFiles(t *testing.T) {
 	}
 }
 
+func TestChangedPathsShimDelegatesToGitfiles(t *testing.T) {
+	dir := initRepo(t)
+	writeFile(t, filepath.Join(dir, ".prettierignore"), "main.go\n")
+	writeFile(t, filepath.Join(dir, "main.go"), "package main\n")
+	gitAdd(t, dir, ".")
+
+	files, err := ChangedPaths(context.Background(), dir, nil)
+
+	if err != nil {
+		t.Fatalf("changed paths: %v", err)
+	}
+
+	// The shim forwards to gitfiles, which does not consult .prettierignore.
+	want := []string{
+		filepath.Join(dir, ".prettierignore"),
+		filepath.Join(dir, "main.go"),
+	}
+
+	if !reflect.DeepEqual(files, want) {
+		t.Fatalf("files mismatch\nwant: %#v\n got: %#v", want, files)
+	}
+}
+
 func initRepo(t *testing.T) string {
 	t.Helper()
 


### PR DESCRIPTION
Stage 3/6 (stacks on G1, sibling of G2). The three unrelated engines bundled in driver/internal/sourcefiles get their own intent-bearing packages: gitfiles (Tree: Files/ChangedPaths/IntersectChanged — the git∩engine set logic moves here from cli/runner.go with its comment), filetypes (Filter: Formattable/Lintable), prettierignore (Matcher: Load/Ignores/FilterAbs — the 240-line matcher promoted with its tests). sourcefiles shrinks to the Collector{Tree,Selection,Filter} composition. Transitional delegating shims keep tsruntime/app/cli untouched until G5 (each marked 'Transitional: G5 adopts <type> directly'). Coverage: gitfiles 94.4%, filetypes 100%, prettierignore 98%, gate 85.8% ✅; self-format clean.