### PR TITLE
feat(filetypes): format the whole TypeScript family, and stop the comment loss it exposed

### DIFF
--- a/packages/go/driver/internal/typescript/filetypes/filetypes.go
+++ b/packages/go/driver/internal/typescript/filetypes/filetypes.go
@@ -9,36 +9,48 @@ import (
 )
 
 // Filter classifies paths by extension. IncludeDeclarations, when set, keeps
-// .d.ts declaration files that would otherwise be dropped.
+// the .d.ts declaration family that would otherwise be dropped.
 type Filter struct {
 	IncludeDeclarations bool
 }
 
-// targetSuffixes are the extensions the sidecar knows how to format. The .ts
-// entry also covers .d.ts; whether declarations are kept is decided separately.
-var targetSuffixes = []string{".ts", ".vue", ".html", ".htm", ".md", ".markdown"}
+// tsFamilySuffixes are the TypeScript-family extensions oxc parses directly.
+// The extension is what selects the parser dialect, so .tsx is what turns JSX
+// on; a .tsx file read as .ts fails to parse the moment it holds an element.
+var tsFamilySuffixes = []string{".ts", ".tsx", ".mts", ".cts"}
+
+// documentSuffixes are the host documents that embed scripts rather than being
+// scripts: their fenced or <script> blocks are what gets formatted.
+var documentSuffixes = []string{".vue", ".html", ".htm", ".md", ".markdown"}
+
+// declarationSuffixes are the declaration forms dropped unless a caller asks
+// for them. There is no .d.tsx: JSX cannot appear in a declaration file.
+var declarationSuffixes = []string{".d.ts", ".d.mts", ".d.cts"}
+
+// hasSuffix reports whether path ends in any of suffixes.
+func hasSuffix(path string, suffixes []string) bool {
+	return slices.ContainsFunc(suffixes, func(suffix string) bool {
+		return strings.HasSuffix(path, suffix)
+	})
+}
 
 // Formattable reports whether path is one the formatter owns: the TS and Vue
 // families plus the HTML and Markdown documents whose embedded scripts get
 // formatted.
 func (f Filter) Formattable(path string) bool {
-	matched := slices.ContainsFunc(targetSuffixes, func(suffix string) bool {
-		return strings.HasSuffix(path, suffix)
-	})
-
-	if !matched {
+	if !hasSuffix(path, tsFamilySuffixes) && !hasSuffix(path, documentSuffixes) {
 		return false
 	}
 
-	return f.IncludeDeclarations || !strings.HasSuffix(path, ".d.ts")
+	return f.IncludeDeclarations || !hasSuffix(path, declarationSuffixes)
 }
 
 // Lintable reports whether oxlint can lint path: the TS family (minus
 // declarations unless IncludeDeclarations) and Vue, but not HTML or Markdown.
 func (f Filter) Lintable(path string) bool {
-	if !strings.HasSuffix(path, ".ts") && !strings.HasSuffix(path, ".vue") {
+	if !hasSuffix(path, tsFamilySuffixes) && !strings.HasSuffix(path, ".vue") {
 		return false
 	}
 
-	return f.IncludeDeclarations || !strings.HasSuffix(path, ".d.ts")
+	return f.IncludeDeclarations || !hasSuffix(path, declarationSuffixes)
 }

--- a/packages/go/driver/internal/typescript/filetypes/filetypes_test.go
+++ b/packages/go/driver/internal/typescript/filetypes/filetypes_test.go
@@ -10,14 +10,20 @@ func TestFormattable(t *testing.T) {
 		want                bool
 	}{
 		{"typescript is formattable", "src/app.ts", false, true},
+		{"tsx is formattable", "src/Screen.tsx", false, true},
+		{"mts is formattable", "src/app.mts", false, true},
+		{"cts is formattable", "src/app.cts", false, true},
 		{"vue is formattable", "src/component.vue", false, true},
 		{"html is formattable", "src/index.html", false, true},
 		{"htm is formattable", "src/index.htm", false, true},
 		{"markdown md is formattable", "docs/notes.md", false, true},
 		{"markdown long form is formattable", "docs/readme.markdown", false, true},
 		{"unknown extensions are skipped", "src/app.go", false, false},
+		{"javascript is not formattable", "src/app.js", false, false},
 		{"declarations drop by default", "src/types.d.ts", false, false},
 		{"declarations kept when requested", "src/types.d.ts", true, true},
+		{"mts declarations drop by default", "src/types.d.mts", false, false},
+		{"cts declarations drop by default", "src/types.d.cts", false, false},
 	}
 
 	for _, tc := range cases {
@@ -39,12 +45,16 @@ func TestLintable(t *testing.T) {
 		want                bool
 	}{
 		{"typescript is lintable", "src/app.ts", false, true},
+		{"tsx is lintable", "src/Screen.tsx", false, true},
+		{"mts is lintable", "src/app.mts", false, true},
+		{"cts is lintable", "src/app.cts", false, true},
 		{"vue is lintable", "src/component.vue", false, true},
 		{"html is not lintable", "src/index.html", false, false},
 		{"markdown is not lintable", "docs/notes.md", false, false},
 		{"unknown extensions are skipped", "src/app.go", false, false},
 		{"declarations drop by default", "src/types.d.ts", false, false},
 		{"declarations kept when requested", "src/types.d.ts", true, true},
+		{"mts declarations drop by default", "src/types.d.mts", false, false},
 	}
 
 	for _, tc := range cases {

--- a/packages/ts/sidecar/src/cli/syntax-cli-dto.ts
+++ b/packages/ts/sidecar/src/cli/syntax-cli-dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ScriptExtensions } from '#sidecar/hosts/script-extensions';
 
 /** Immutable command-line options for standalone syntax validation. */
 export class SyntaxCliDto {
@@ -28,7 +29,7 @@ export class SyntaxCliDto {
 		const argv = SyntaxCliDto.#argvSchema.parse(input);
 
 		const files = argv.filter((file) => {
-			return file.endsWith('.ts') || file.endsWith('.vue');
+			return ScriptExtensions.isScript(file) || file.endsWith('.vue');
 		});
 
 		return new SyntaxCliDto(SyntaxCliDto.#schema.parse({ files }));

--- a/packages/ts/sidecar/src/cli/validate-syntax.test.ts
+++ b/packages/ts/sidecar/src/cli/validate-syntax.test.ts
@@ -80,6 +80,44 @@ test('accepts Vue TSX and JSX script blocks', async () => {
 	);
 });
 
+test('accepts standalone TSX, MTS, and CTS files', async () => {
+	await withFixture(
+		{
+			'Screen.tsx': 'export const Screen = (): JSX.Element => <section>Ready</section>;\n',
+			'loader.mts': 'export const load = async (): Promise<number> => 1;\n',
+			'legacy.cts': 'export const value: number = 1;\n',
+		},
+		async (dir) => {
+			const result = spawnSync(
+				process.execPath,
+				['--import', tsx, script, 'Screen.tsx', 'loader.mts', 'legacy.cts'],
+				{ cwd: dir, encoding: 'utf8' },
+			);
+
+			assert.equal(result.status, 0, result.stderr || result.stdout);
+			assert.match(result.stdout, /\[validate-syntax\] checked 3 file\(s\)/);
+		},
+	);
+});
+
+test('reports TSX syntax errors on original file lines', async () => {
+	await withFixture(
+		{
+			'Broken.tsx': 'export const Screen = () => <section>Ready</div>;\n',
+		},
+		async (dir) => {
+			const result = spawnSync(
+				process.execPath,
+				['--import', tsx, script, 'Broken.tsx'],
+				{ cwd: dir, encoding: 'utf8' },
+			);
+
+			assert.equal(result.status, 1);
+			assert.match(result.stderr, /\[validate-syntax\].*Broken\.tsx/);
+		},
+	);
+});
+
 test('reports Vue syntax errors on original file lines', async () => {
 	await withFixture(
 		{

--- a/packages/ts/sidecar/src/hosts/file-target-policy.test.ts
+++ b/packages/ts/sidecar/src/hosts/file-target-policy.test.ts
@@ -12,6 +12,12 @@ const targets = new FileTargetPolicy({
 test('isTargetFile accepts ts and host documents but not declarations', () => {
 	assert.equal(targets.isTargetFile('app.ts'), true);
 
+	assert.equal(targets.isTargetFile('Screen.tsx'), true);
+
+	assert.equal(targets.isTargetFile('app.mts'), true);
+
+	assert.equal(targets.isTargetFile('app.cts'), true);
+
 	assert.equal(targets.isTargetFile('widget.vue'), true);
 
 	assert.equal(targets.isTargetFile('page.html'), true);
@@ -24,11 +30,17 @@ test('isTargetFile accepts ts and host documents but not declarations', () => {
 
 	assert.equal(targets.isTargetFile('types.d.ts'), false);
 
+	assert.equal(targets.isTargetFile('types.d.mts'), false);
+
+	assert.equal(targets.isTargetFile('types.d.cts'), false);
+
 	assert.equal(targets.isTargetFile('data.json'), false);
 });
 
 test('isSyntaxTarget accepts every ts file plus host documents', () => {
 	assert.equal(targets.isSyntaxTarget('app.ts'), true);
+
+	assert.equal(targets.isSyntaxTarget('Screen.tsx'), true);
 
 	assert.equal(targets.isSyntaxTarget('types.d.ts'), true);
 
@@ -41,8 +53,14 @@ test('isSyntaxTarget accepts every ts file plus host documents', () => {
 	assert.equal(targets.isSyntaxTarget('data.json'), false);
 });
 
-test('isDeclarationFile only matches .d.ts', () => {
+test('isDeclarationFile only matches the declaration family', () => {
 	assert.equal(targets.isDeclarationFile('types.d.ts'), true);
 
+	assert.equal(targets.isDeclarationFile('types.d.mts'), true);
+
+	assert.equal(targets.isDeclarationFile('types.d.cts'), true);
+
 	assert.equal(targets.isDeclarationFile('app.ts'), false);
+
+	assert.equal(targets.isDeclarationFile('Screen.tsx'), false);
 });

--- a/packages/ts/sidecar/src/hosts/file-target-policy.ts
+++ b/packages/ts/sidecar/src/hosts/file-target-policy.ts
@@ -1,4 +1,5 @@
 import type { EmbeddedBlockSplitter } from '#sidecar/hosts/embedded-block-splitter';
+import { ScriptExtensions } from '#sidecar/hosts/script-extensions';
 
 /** Classifies paths accepted by sidecar formatting passes. */
 export class FileTargetPolicy {
@@ -16,10 +17,10 @@ export class FileTargetPolicy {
 	 * Report whether a virtual filename denotes a TypeScript declaration file.
 	 *
 	 * @param virtualName - The filename to classify.
-	 * @returns `true` when the filename ends in `.d.ts`.
+	 * @returns `true` when the filename ends in `.d.ts`, `.d.mts`, or `.d.cts`.
 	 */
 	isDeclarationFile(virtualName: string): boolean {
-		return virtualName.endsWith('.d.ts');
+		return ScriptExtensions.isDeclaration(virtualName);
 	}
 
 	/**
@@ -29,7 +30,7 @@ export class FileTargetPolicy {
 	 * @returns `true` for host documents and non-declaration TypeScript files.
 	 */
 	isTargetFile(path: string): boolean {
-		return (path.endsWith('.ts') && !path.endsWith('.d.ts')) || this.#embeddedBlocks.isHost(path);
+		return (ScriptExtensions.isScript(path) && !ScriptExtensions.isDeclaration(path)) || this.#embeddedBlocks.isHost(path);
 	}
 
 	/**
@@ -39,6 +40,6 @@ export class FileTargetPolicy {
 	 * @returns `true` for host documents and every TypeScript file.
 	 */
 	isSyntaxTarget(path: string): boolean {
-		return path.endsWith('.ts') || this.#embeddedBlocks.isHost(path);
+		return ScriptExtensions.isScript(path) || this.#embeddedBlocks.isHost(path);
 	}
 }

--- a/packages/ts/sidecar/src/hosts/script-extensions.ts
+++ b/packages/ts/sidecar/src/hosts/script-extensions.ts
@@ -1,0 +1,34 @@
+/**
+ * The TypeScript-family extension taxonomy, shared so the formatting passes and
+ * the standalone syntax CLI cannot drift apart on which files they accept.
+ *
+ * The extension selects the parser dialect, so `.tsx` is what turns JSX on: a
+ * `.tsx` file classified as `.ts` fails to parse the moment it holds an element.
+ */
+export class ScriptExtensions {
+	/** TypeScript-family extensions oxc parses directly. */
+	static readonly #script = ['.ts', '.tsx', '.mts', '.cts'];
+
+	/** Declaration forms. There is no `.d.tsx`: JSX cannot appear in one. */
+	static readonly #declaration = ['.d.ts', '.d.mts', '.d.cts'];
+
+	/**
+	 * Report whether a path denotes a TypeScript-family script.
+	 *
+	 * @param path - The path to classify.
+	 * @returns `true` for `.ts`, `.tsx`, `.mts`, and `.cts`, declarations included.
+	 */
+	static isScript(path: string): boolean {
+		return ScriptExtensions.#script.some((suffix) => path.endsWith(suffix));
+	}
+
+	/**
+	 * Report whether a path denotes a TypeScript declaration file.
+	 *
+	 * @param path - The path to classify.
+	 * @returns `true` for `.d.ts`, `.d.mts`, and `.d.cts`.
+	 */
+	static isDeclaration(path: string): boolean {
+		return ScriptExtensions.#declaration.some((suffix) => path.endsWith(suffix));
+	}
+}

--- a/packages/ts/sidecar/src/passes/declaration-reorder-pass.test.ts
+++ b/packages/ts/sidecar/src/passes/declaration-reorder-pass.test.ts
@@ -56,3 +56,37 @@ test('reorders import groups so single-line imports precede multiline ones', () 
 test('returns no edits for source with syntax errors', () => {
 	assert.deepEqual(computeEdits('const broken = {;\nconst small = 1;\n'), []);
 });
+
+test('declines to reorder a const group holding a comment between declarations', () => {
+	const source = ['const small = 1;', '// Explains the next declaration.', '// Second line of the explanation.', 'const big = {', '\tone: 1,', '};', ''].join('\n');
+
+	assert.deepEqual(computeEdits(source), []);
+
+	assert.equal(reorder(source), source);
+});
+
+test('declines to reorder a const group holding a trailing comment beside a declaration', () => {
+	const source = ['const small = 1; // Why this value.', 'const big = {', '\tone: 1,', '};', ''].join('\n');
+
+	assert.deepEqual(computeEdits(source), []);
+});
+
+test('declines to reorder a const group holding a block comment between declarations', () => {
+	const source = ['const small = 1;', '/* Explains the next declaration. */', 'const big = {', '\tone: 1,', '};', ''].join('\n');
+
+	assert.deepEqual(computeEdits(source), []);
+});
+
+test('declines to reorder an import group holding a comment between declarations', () => {
+	const source = ["import { tiny } from 'narrow';", '// Explains the wide import.', 'import {', '\talpha,', '\tbeta,', "} from 'wide';", ''].join('\n');
+
+	assert.deepEqual(computeEdits(source), []);
+});
+
+test('still reorders a group whose only comment sits above the first declaration', () => {
+	const source = ['// Explains the whole group.', 'const big = {', '\tone: 1,', '};', 'const small = 1;', ''].join('\n');
+
+	const result = reorder(source);
+
+	assert.match(result, /^\/\/ Explains the whole group\.\nconst small = 1;\n\nconst big = \{/);
+});

--- a/packages/ts/sidecar/src/passes/declaration-reorder-pass.ts
+++ b/packages/ts/sidecar/src/passes/declaration-reorder-pass.ts
@@ -262,6 +262,15 @@ export class DeclarationReorderPass implements FormattingPass {
 	}
 
 	#groupEdit(document: SourceDocument, group: Node[], canReorder: boolean): Edit | null {
+		// A group edit rewrites the whole span from the first declaration to the last
+		// out of node text alone, so anything living in the gaps between them — a
+		// comment above an inner declaration, or trailing one beside it — is not
+		// reproduced and would be deleted. Decline the reorder instead: losing a
+		// cosmetic ordering is recoverable, losing a comment is not.
+		if (this.#hasCommentBetweenMembers(document, group)) {
+			return null;
+		}
+
 		const singleLine = group.filter((node) => {
 			return !this.#isMultiline(document, node);
 		});
@@ -318,5 +327,35 @@ export class DeclarationReorderPass implements FormattingPass {
 			end: lastEnd,
 			replacement,
 		};
+	}
+
+	#hasCommentBetweenMembers(document: SourceDocument, group: Node[]): boolean {
+		for (let i = 0; i < group.length - 1; i++) {
+			const current = group[i];
+			const following = group[i + 1];
+
+			if (!current || !following) {
+				continue;
+			}
+
+			const gapStart = this.#ast.getEnd(current);
+			const gapEnd = this.#ast.getStart(following);
+
+			if (gapStart < 0 || gapEnd < 0 || gapEnd <= gapStart) {
+				continue;
+			}
+
+			// Only whitespace and comments can sit between two statements, so
+			// scanning the gap text for a comment opener needs no tokenizing.
+			if (this.#containsComment(document.slice(gapStart, gapEnd))) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	#containsComment(source: string): boolean {
+		return /\/\/|\/\*/.test(source);
 	}
 }


### PR DESCRIPTION
Two commits: widening the extension taxonomy to `.tsx`, and fixing the data-loss bug that widening exposed. The second is the more important one — **it is a pre-existing defect that deletes comments from plain `.ts` files too.**

## 1. `.tsx` was silently skipped

The taxonomy recognised `.ts` but not `.tsx`, so every `.tsx` file was dropped before it reached oxfmt or oxlint. This fails silently: the driver reports `processed 0 file(s)` rather than an error, so a repository of React Native screens formats "clean" while none of its `.tsx` files are ever touched.

```
# before: one unformatted .tsx fixture
[blank-lines] processed 0 file(s), 0 changed
[validate-syntax] checked 0 file(s)      # file unchanged

# after
[blank-lines] updated Screen.tsx
[validate-syntax] checked 1 file(s)      # JSX correctly reformatted
```

This was never a parser gap. oxc, oxfmt, and oxlint all handle JSX natively, and the sidecar already maps `tsx`/`jsx` script kinds for Vue `<script lang="tsx">` blocks and Markdown fences. The extension selects the parser dialect, so passing a `.tsx` filename to `parseSync` is sufficient — only the file-level gates were narrow.

Widened to the TypeScript family — `.ts`, `.tsx`, `.mts`, `.cts` — with the declaration exclusion extended to `.d.mts` and `.d.cts`. There is no `.d.tsx`: JSX cannot appear in a declaration file.

The gate lived in four places that could drift apart, and had:

- `filetypes.go` — `Formattable` and `Lintable`
- `file-target-policy.ts` — `isTargetFile`, `isSyntaxTarget`, `isDeclarationFile`
- `syntax-cli-dto.ts` — the argument filter

The sidecar side now shares one `ScriptExtensions` taxonomy so a future extension is added in one place.

Plain `.js`, `.jsx`, `.mjs`, and `.cjs` stay **out of scope**: formatting those is a behavioural change for every consumer carrying build config at the repo root (`metro.config.js`, `babel.config.js`), and is not needed to close the `.tsx` hole.

## 2. `DeclarationReorderPass` was deleting comments

Pointing the widened formatter at a real React Native app immediately destroyed source. `DeclarationReorderPass` rewrites a run of consecutive declarations by rebuilding the whole span from first to last out of node text alone. Nothing reproduced the gaps between those nodes, so **any comment living in one was replaced by the computed separator and lost.**

Measured on three real screens, one pass each:

| file | comment lines before | after |
|---|---|---|
| `button.tsx` | 7 | **0** |
| `OtpScreen.tsx` | 11 | 7 |
| `PortfolioScreen.tsx` | 8 | 6 |

`button.tsx` lost the entire seven-line note explaining why `useAnimatedStyle` is called without optional-call syntax and that a release build otherwise aborts on first render. That is not a cosmetic loss.

The offset shift left by the deletion also mis-applied a later edit in the same run, emitting a stray `};` that made the file unparsable — the `Unexpected token` oxfmt reported. Fixing the deletion fixed both.

### Why this matters beyond `.tsx`

**It reproduces in plain `.ts`.** The same fixture with the JSX removed loses its comments identically. The edit only fires when the group is not already settled, so an already-formatted tree never triggers it — which is why the damage stayed invisible, and why widening the taxonomy surfaced it all at once across a directory that had never been formatted. Any comment newly written directly above a declaration in an unsettled group is exposed today.

### The fix

`ClassReorderPass` already guards precisely this case with `#hasCommentsAroundMembers`, declining to reorder rather than risk its members' comments. The same guard now applies to declaration groups: check the gaps between consecutive members, return no edit when one holds a comment. Only whitespace and comments can sit between two statements, so scanning the gap for a comment opener needs no tokenizing — the same reasoning the class pass relies on.

A comment above the *first* declaration sits outside the rewritten span and still reorders as before; there is a test pinning that.

Declining is the conservative half of the trade: losing a cosmetic ordering is recoverable, losing a comment is not. Carrying each comment along with the declaration it documents is the better end state and is left as follow-up.

## Verification

- sidecar suite: **194/194 pass**, including 5 new comment-preservation cases and new standalone `.tsx`/`.mts`/`.cts` and broken-JSX cases
- `go -C packages/go test ./...` — all pass
- `tsc --noEmit`, `oxlint` — clean
- `./scripts/task.sh self-check` — repository is fmtkit-formatted
- Re-ran the full pipeline over the three real screens after the fix: all comments preserved, no stray tokens, `validate-syntax` clean
- Templates re-verified: `.html` `<script>` blocks and Markdown ` ```tsx ` fences format as before

## Downstream note

Consumers whose `.tsx` files have never been formatted will see a large one-time diff on the first release carrying this. **That diff is only safe with commit 2 included** — the taxonomy change alone would delete comments at scale.